### PR TITLE
app: fix antivenom chip explosion in filter panel

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -1024,39 +1024,37 @@
             opt.textContent = states[code] + ' (' + code + ')';
             sel.appendChild(opt);
         });
-        // Antivenom chips
-        var allTypes = {};
-        hospitals.forEach(function(h) {
-            if (h.antivenoms) h.antivenoms.forEach(function(a) {
-                var key = norm(a);
-                if (!allTypes[key]) allTypes[key] = a;
-            });
-        });
-        var chipContainer = document.getElementById('antivenom-chips');
+        // Antivenom chips — canonical types only. The downstream filter uses
+        // substring match on norm(a), so a single canonical chip covers all
+        // raw variants in the data (e.g. "Botrópico", "Botrópico.",
+        // "Botrópico e Crotálico"). Rendering every raw variant was producing
+        // 70+ noisy chips including typos, full sentences, and abbreviations.
+        var CHIP_LABELS = {
+            escorpionico: 'Escorpiônico',
+            botropico:    'Botrópico',
+            crotalico:    'Crotálico',
+            laquetico:    'Laquético',
+            elapidico:    'Elapídico',
+            foneutrico:   'Fonêutrico',
+            loxoscelico:  'Loxoscélico',
+            lonomico:     'Lonômico'
+        };
         var chipOrder = ['escorpionico','botropico','crotalico','laquetico','elapidico','foneutrico','loxoscelico','lonomico'];
+        var chipContainer = document.getElementById('antivenom-chips');
         chipOrder.forEach(function(key) {
-            for (var k in allTypes) {
-                if (k.indexOf(key) !== -1) {
-                    var btn = document.createElement('button');
-                    btn.className = 'chip';
-                    btn.dataset.type = key;
-                    btn.textContent = allTypes[k];
-                    btn.onclick = function() { onChipClick(this.dataset.type); };
-                    chipContainer.appendChild(btn);
-                    delete allTypes[k];
-                    break;
-                }
-            }
-        });
-        // Any remaining types
-        for (var k in allTypes) {
+            var hasMatch = hospitals.some(function(h) {
+                return h.antivenoms && h.antivenoms.some(function(a) {
+                    return norm(a).indexOf(key) !== -1;
+                });
+            });
+            if (!hasMatch) return;
             var btn = document.createElement('button');
             btn.className = 'chip';
-            btn.dataset.type = k;
-            btn.textContent = allTypes[k];
+            btn.dataset.type = key;
+            btn.textContent = CHIP_LABELS[key];
             btn.onclick = function() { onChipClick(this.dataset.type); };
             chipContainer.appendChild(btn);
-        }
+        });
     }
 
     // ===== RENDER CARD =====


### PR DESCRIPTION
## What

Opening the filter used to show 70+ chips including typos (\`Escoepiônico\`), full sentences (\`É suprido pela rede de frio quando...\`), MA abbreviations (\`SAB\`, \`SABC\`, \`SABL\`, \`SAAr\`, \`SAEsc\`), and pentavalent combos (\`Botrópico; Crotálico; Elapídico; Laquético; Aracnídeo\`).

## Why it broke

\`populateFilters\` matched one raw variant per canonical type, then dumped every leftover raw string in \`hospitals.json\` as its own chip. The downstream filter already substring-matches canonical keys against normalized raw entries, so leftover chips were pure noise. Bug was always present but grew visible as \`hospitals.json\` accumulated more variant phrasings from automated rebuilds.

## Fix

Render only the 8 canonical types with deterministic Portuguese labels, skip any type with zero matching hospitals in the data. Selection contract unchanged (\`data-type\` = canonical key, substring-matched downstream).

\`\`\`
Escorpiônico  Botrópico  Crotálico  Laquético
Elapídico     Fonêutrico Loxoscélico Lonômico
\`\`\`

## Known gap (not fixed here)

MA's \`SAB*\` / \`SAC\` / \`SAAr\` / \`SAEsc\` abbreviations contain no canonical key substring, so hospitals listing only those are not chip-filterable today. Proper fix is in the data-extraction pipeline — expand abbreviations at \`hospitals.json\` build time.

## Test plan

- [x] Filter panel shows 8 clean chips
- [x] Clicking \`Botrópico\` filters the list; chip goes active
- [x] No console errors
- [x] Works in both light and dark themes