### PR TITLE
sheet: make setupSheet idempotent for existing filters

### DIFF
--- a/scripts/sheet/Code.gs
+++ b/scripts/sheet/Code.gs
@@ -70,6 +70,8 @@ function setupSheet() {
   let hosp = ss.getSheetByName(HOSPITALS_SHEET);
   if (!hosp) hosp = ss.insertSheet(HOSPITALS_SHEET);
   hosp.clear();
+  const hospFilter = hosp.getFilter();
+  if (hospFilter) hospFilter.remove();
   hosp.getRange(1, 1, 1, HOSPITAL_HEADERS.length)
       .setValues([HOSPITAL_HEADERS])
       .setFontWeight('bold');
@@ -79,6 +81,8 @@ function setupSheet() {
   let over = ss.getSheetByName(OVERRIDES_SHEET);
   if (!over) over = ss.insertSheet(OVERRIDES_SHEET);
   over.clear();
+  const overFilter = over.getFilter();
+  if (overFilter) overFilter.remove();
   over.getRange(1, 1, 1, OVERRIDE_HEADERS.length)
       .setValues([OVERRIDE_HEADERS])
       .setFontWeight('bold');


### PR DESCRIPTION
## Summary
- Remove any existing filter on the Hospitals and Overrides tabs before calling `createFilter()` in `setupSheet()`, so re-running setup after the first time no longer throws `"You can't create a filter in a sheet that already has a filter."`
- Previously that exception fired after `hosp.clear()` had already wiped data but before the Overrides tab was rebuilt, leaving the sheet half-configured. We hit this during the 2026-04-20 rollout when extending the Overrides schema with `corrected_address`.
- Same defensive `getFilter()` / `remove()` pattern applied to the Overrides tab for symmetry, even though it currently has no filter.

## Test plan
- [ ] Paste the updated `scripts/sheet/Code.gs` into the live Apps Script editor (Extensions → Apps Script) and save.
- [ ] On a sheet that already has a filter on the Hospitals tab, run `SoroJá → Setup sheet` and confirm it completes without the filter exception and that both tabs are fully rebuilt.
- [ ] Run `SoroJá → Refresh hospitals list` afterward and confirm the Hospitals tab repopulates normally.

**Reminder:** merging this PR only updates the repo copy of the script. The live sheet still needs the updated `Code.gs` pasted into the Apps Script editor for the fix to take effect.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PZe88qZJnVRozBbdVTM8az)_