### PR TITLE
data: preservar soros em observações mistas

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install pytest
         run: pip install pytest
 
-      - name: Canonicalizer self-test (32 asserts on raw variants)
+      - name: Canonicalizer self-test
         run: python3 scripts/canonicalize_antivenoms.py --self-test
 
       - name: Pytest suite

--- a/app/hospitals.json
+++ b/app/hospitals.json
@@ -5415,7 +5415,9 @@
       "(77)3466 2111"
     ],
     "cnes": "2556901",
-    "antivenoms": [],
+    "antivenoms": [
+      "Escorpiônico"
+    ],
     "source_antivenoms_raw": [
       "Antiescorpiônico. Os demais, são supridos pela rede de frio quando do atendimento de ocorrência, dada a proximidade"
     ],
@@ -6658,7 +6660,9 @@
       "(77)34652237"
     ],
     "cnes": "2412551",
-    "antivenoms": [],
+    "antivenoms": [
+      "Escorpiônico"
+    ],
     "source_antivenoms_raw": [
       "Escorpiônico. (Os demais são supridos pela Rede de Frio quando atendimento de ocorrência)."
     ],
@@ -6837,7 +6841,9 @@
       "(77) 3466-2112"
     ],
     "cnes": "2627256",
-    "antivenoms": [],
+    "antivenoms": [
+      "Escorpiônico"
+    ],
     "source_antivenoms_raw": [
       "Escorpiônico. Os demais são supridos pela rede de frio quando do atendimento de ocorrência."
     ],

--- a/hospitals.json
+++ b/hospitals.json
@@ -5415,7 +5415,9 @@
       "(77)3466 2111"
     ],
     "cnes": "2556901",
-    "antivenoms": [],
+    "antivenoms": [
+      "Escorpiônico"
+    ],
     "source_antivenoms_raw": [
       "Antiescorpiônico. Os demais, são supridos pela rede de frio quando do atendimento de ocorrência, dada a proximidade"
     ],
@@ -6658,7 +6660,9 @@
       "(77)34652237"
     ],
     "cnes": "2412551",
-    "antivenoms": [],
+    "antivenoms": [
+      "Escorpiônico"
+    ],
     "source_antivenoms_raw": [
       "Escorpiônico. (Os demais são supridos pela Rede de Frio quando atendimento de ocorrência)."
     ],
@@ -6837,7 +6841,9 @@
       "(77) 3466-2112"
     ],
     "cnes": "2627256",
-    "antivenoms": [],
+    "antivenoms": [
+      "Escorpiônico"
+    ],
     "source_antivenoms_raw": [
       "Escorpiônico. Os demais são supridos pela rede de frio quando do atendimento de ocorrência."
     ],

--- a/scripts/canonicalize_antivenoms.py
+++ b/scripts/canonicalize_antivenoms.py
@@ -225,6 +225,10 @@ def _is_leak(raw: str) -> bool:
     return False
 
 
+def _is_judicial_note(raw: str) -> bool:
+    return bool(re.search(r"judicial", raw, re.IGNORECASE))
+
+
 def _is_non_antivenom(norm: str) -> bool:
     for pat in NON_ANTIVENOM_PATTERNS:
         if pat.search(norm):
@@ -258,6 +262,18 @@ def _try_patterns(norm: str) -> List[str]:
     return found
 
 
+def _try_mentions_in_text(norm: str) -> List[str]:
+    """Extract canonical names embedded in longer observation text.
+
+    Mixed source cells such as "Escorpiônico. Os demais são supridos..."
+    are both useful antivenom data and an operational note. Normal splitting
+    treats the long sentence as a leak, so this punctuation-normalized pass
+    rescues the canonical mention before the full raw cell is moved to `note`.
+    """
+    search_norm = re.sub(r"[^a-z0-9]+", " ", norm).strip()
+    return _try_patterns(search_norm)
+
+
 # ---------------------------------------------------------------------------
 # API pública
 # ---------------------------------------------------------------------------
@@ -273,11 +289,15 @@ def canonicalize_one(raw: str) -> Tuple[List[str], str]:
     if not raw or not raw.strip():
         return [], "unknown"
 
-    # 1) Vazamento óbvio por frase
-    if _is_leak(raw):
-        return [], "leak"
-
     norm = _normalize(raw)
+
+    # 1) Vazamento óbvio por frase. Before classifying it as note-only,
+    # rescue any canonical antivenom mention embedded in the observation.
+    if _is_leak(raw):
+        mentions = [] if _is_judicial_note(raw) else _try_mentions_in_text(norm)
+        if mentions:
+            return mentions, "canonical"
+        return [], "leak"
 
     # 2) Divide por delimitadores e resolve cada parte
     parts = [p.strip() for p in SPLIT_PATTERN.split(norm) if p.strip()]
@@ -333,6 +353,8 @@ def canonicalize_list(raw_list: Iterable[str]) -> CanonicalResult:
                 # preserva ordem mas deduplica global
                 if c not in seen_canonical:
                     seen_canonical.append(c)
+            if _is_leak(raw) and raw not in result.leaks:
+                result.leaks.append(raw)
         elif category == "leak":
             if raw not in result.leaks:
                 result.leaks.append(raw)
@@ -485,6 +507,16 @@ def _self_test():
     ) == ([], "leak")
     assert canonicalize_one("É suprido pelo Hospital Clériston Andrade, quando necessário") == ([], "leak")
     assert canonicalize_one("É suprido pelo CIATox quando do atendimento de ocorrência, dada a proximidade") == ([], "leak")
+    assert canonicalize_one(
+        "Antiescorpiônico. Os demais, são supridos pela rede de frio quando do atendimento de ocorrência, dada a proximidade"
+    ) == (["Escorpiônico"], "canonical")
+    assert canonicalize_one(
+        "Escorpiônico. (Os demais são supridos pela Rede de Frio quando atendimento de ocorrência)."
+    ) == (["Escorpiônico"], "canonical")
+    assert canonicalize_one(
+        "Escorpiônico. Os demais são supridos pela rede de frio quando do atendimento de ocorrência."
+    ) == (["Escorpiônico"], "canonical")
+    assert canonicalize_one("Elapídico (judicial)") == ([], "leak")
 
     # Soros NÃO-antiveneno
     assert canonicalize_one("Antirrábico") == ([], "non_antivenom")
@@ -516,6 +548,14 @@ def _self_test():
     assert res.canonical == ["Botrópico", "Escorpiônico", "Laquético", "Fonêutrico", "Lonômico"]
     assert len(res.leaks) == 1
     assert res.other_soros == ["Antirrábico"]
+
+    mixed = canonicalize_list([
+        "Escorpiônico. Os demais são supridos pela rede de frio quando do atendimento de ocorrência."
+    ])
+    assert mixed.canonical == ["Escorpiônico"]
+    assert mixed.leaks == [
+        "Escorpiônico. Os demais são supridos pela rede de frio quando do atendimento de ocorrência."
+    ]
     assert res.unknown == []
 
     print("✓ Todos os testes passaram.")

--- a/scripts/tests/test_canonicalize.py
+++ b/scripts/tests/test_canonicalize.py
@@ -1,6 +1,6 @@
 """Pytest wrapper around the canonicalizer's built-in self-test.
 
-The 32 assertions live in `canonicalize_antivenoms._self_test`. This file
+The main regression assertions live in `canonicalize_antivenoms._self_test`. This file
 wires them into pytest so CI catches regressions, plus adds a handful of
 inline checks on the public API shape.
 """
@@ -47,3 +47,22 @@ def test_leak_example_from_ba_pdf():
 def test_canonical_deduplicates_across_variants():
     result = canonicalize_list(["Botrópico", "Botrópico.", "BOTRÓPICO", "Botropico"])
     assert result.canonical == ["Botrópico"]
+
+
+def test_mixed_escorpionico_notes_keep_antivenom_and_note():
+    raw_values = [
+        "Antiescorpiônico. Os demais, são supridos pela rede de frio quando do atendimento de ocorrência, dada a proximidade",
+        "Escorpiônico. (Os demais são supridos pela Rede de Frio quando atendimento de ocorrência).",
+        "Escorpiônico. Os demais são supridos pela rede de frio quando do atendimento de ocorrência.",
+    ]
+
+    for raw in raw_values:
+        result = canonicalize_list([raw])
+        assert result.canonical == ["Escorpiônico"]
+        assert result.leaks == [raw]
+
+
+def test_judicial_note_remains_note_only():
+    result = canonicalize_list(["Elapídico (judicial)"])
+    assert result.canonical == []
+    assert result.leaks == ["Elapídico (judicial)"]


### PR DESCRIPTION
## O que mudou
- O canonicalizer agora resgata menções canônicas dentro de observações mistas, como 'Escorpiônico. Os demais são supridos...'.
- A observação completa continua indo para note, preservando o contexto operacional.
- Casos com 'judicial' continuam como nota sem virar tag pública.
- Adiciona regressões para Caetité, Ibiassucê e Igaporã.
- Regera app/hospitals.json e hospitals.json.

## Impacto no app
Três hospitais da BA que mencionavam Escorpiônico na fonte passam a aparecer no filtro/tag de Escorpiônico:
- Caetité — Centro de saúde Dra. Lara Fernandes Teixeira
- Ibiassucê — Hospital Municipal de Ibiassucê
- Igaporã — Hospital Municipal José Olinto Cotrim

## Validação
- python3 scripts/canonicalize_antivenoms.py --self-test
- testes direcionados de canonicalize via import direto
- python3 scripts/build_app_hospitals_json.py
- verificação de diff: só 3 registros mudam antivenoms, todos para ['Escorpiônico']
- python3 scripts/validate_hospitals_json.py app/hospitals.json
- python3 scripts/phone_utils.py

Observação: python3 -m pytest scripts/tests/ -v não rodou localmente porque este Python não tem pytest instalado; o CI instala pytest.