### PR TITLE
ci: validate community notes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,5 +30,8 @@ jobs:
       - name: Pytest suite
         run: python3 -m pytest scripts/tests/ -v
 
+      - name: Validate community notes
+        run: python3 scripts/validate_community_notes.py
+
       - name: Validate app/hospitals.json schema
         run: python3 scripts/validate_hospitals_json.py app/hospitals.json

--- a/.github/workflows/rebuild-hospitals-on-override.yml
+++ b/.github/workflows/rebuild-hospitals-on-override.yml
@@ -26,6 +26,9 @@ jobs:
         with:
           python-version: '3.11'
 
+      - name: Validate community notes
+        run: python3 scripts/validate_community_notes.py
+
       - name: Rebuild hospitals.json
         run: python3 scripts/build_app_hospitals_json.py
 

--- a/scripts/tests/test_validate_community_notes.py
+++ b/scripts/tests/test_validate_community_notes.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import validate_community_notes as validator  # noqa: E402
+
+
+def write_json(path: Path, data: object) -> None:
+    path.write_text(json.dumps(data), encoding="utf-8")
+
+
+def write_hospitals(path: Path, cnes_values: list[str]) -> None:
+    write_json(path, [{"cnes": cnes, "hospital_name": f"H {cnes}"} for cnes in cnes_values])
+
+
+def test_valid_notes_pass(tmp_path: Path):
+    notes = tmp_path / "community_notes.json"
+    hospitals = tmp_path / "hospitals.json"
+    write_hospitals(hospitals, ["123"])
+    write_json(
+        notes,
+        {
+            "generated_at": "2026-06-22",
+            "notes": {
+                "123": [
+                    {
+                        "category": "contact_fix",
+                        "reported_at": "2026-06-21",
+                        "public_summary": "Relato da comunidade: telefone atualizado.",
+                    }
+                ]
+            },
+        },
+    )
+
+    assert validator.validate(notes, hospitals) == []
+
+
+def test_rejects_unknown_cnes_and_category(tmp_path: Path):
+    notes = tmp_path / "community_notes.json"
+    hospitals = tmp_path / "hospitals.json"
+    write_hospitals(hospitals, ["123"])
+    write_json(
+        notes,
+        {
+            "generated_at": "2026-06-22",
+            "notes": {
+                "999": [
+                    {
+                        "category": "source_contribution",
+                        "reported_at": "2026-06-21",
+                        "public_summary": "Relato da comunidade: texto.",
+                    }
+                ]
+            },
+        },
+    )
+
+    errors = validator.validate(notes, hospitals)
+
+    assert "CNES 999: CNES is not present in app/hospitals.json" in errors
+    assert any("category must be one of" in error for error in errors)
+
+
+def test_rejects_empty_reference_cnes_set(tmp_path: Path):
+    notes = tmp_path / "community_notes.json"
+    hospitals = tmp_path / "hospitals.json"
+    write_hospitals(hospitals, [])
+    write_json(
+        notes,
+        {
+            "generated_at": "2026-06-22",
+            "notes": {
+                "123": [
+                    {
+                        "category": "contact_fix",
+                        "reported_at": "2026-06-21",
+                        "public_summary": "Relato da comunidade: telefone atualizado.",
+                    }
+                ]
+            },
+        },
+    )
+
+    errors = validator.validate(notes, hospitals)
+
+    assert any("no CNES values found for reference checks" in error for error in errors)
+    assert "CNES 123: CNES is not present in app/hospitals.json" in errors
+
+
+def test_rejects_bad_dates_and_expiry_order(tmp_path: Path):
+    notes = tmp_path / "community_notes.json"
+    hospitals = tmp_path / "hospitals.json"
+    write_hospitals(hospitals, ["123"])
+    write_json(
+        notes,
+        {
+            "generated_at": "not-a-date",
+            "notes": {
+                "123": [
+                    {
+                        "category": "closed",
+                        "reported_at": "2026-06-21",
+                        "expires_at": "2026-06-21",
+                        "public_summary": "Relato da comunidade: local pode estar fechado.",
+                    }
+                ]
+            },
+        },
+    )
+
+    errors = validator.validate(notes, hospitals)
+
+    assert any("generated_at must be YYYY-MM-DD" in error for error in errors)
+    assert "CNES 123 note 1: expires_at must be after reported_at" in errors
+
+
+def test_rejects_non_calendar_iso_date_forms(tmp_path: Path):
+    notes = tmp_path / "community_notes.json"
+    hospitals = tmp_path / "hospitals.json"
+    write_hospitals(hospitals, ["123"])
+    write_json(
+        notes,
+        {
+            "generated_at": "2026-W26-1",
+            "notes": {
+                "123": [
+                    {
+                        "category": "closed",
+                        "reported_at": "20260621",
+                        "public_summary": "Relato da comunidade: local pode estar fechado.",
+                    }
+                ]
+            },
+        },
+    )
+
+    errors = validator.validate(notes, hospitals)
+
+    assert any("generated_at must be YYYY-MM-DD" in error for error in errors)
+    assert "CNES 123 note 1: reported_at must be YYYY-MM-DD" in errors
+
+
+def test_rejects_long_summary_and_unknown_keys(tmp_path: Path):
+    notes = tmp_path / "community_notes.json"
+    hospitals = tmp_path / "hospitals.json"
+    write_hospitals(hospitals, ["123"])
+    write_json(
+        notes,
+        {
+            "generated_at": "2026-06-22",
+            "notes": {
+                "123": [
+                    {
+                        "category": "other",
+                        "reported_at": "2026-06-21",
+                        "public_summary": "x" * (validator.SUMMARY_MAX + 1),
+                        "raw_report": "must not publish raw text",
+                    }
+                ]
+            },
+        },
+    )
+
+    errors = validator.validate(notes, hospitals)
+
+    assert f"CNES 123 note 1: public_summary exceeds {validator.SUMMARY_MAX} characters" in errors
+    assert "CNES 123 note 1: unknown key(s): raw_report" in errors

--- a/scripts/validate_community_notes.py
+++ b/scripts/validate_community_notes.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Validate data/community_notes.json before it reaches the public app."""
+
+from __future__ import annotations
+
+from datetime import date
+import json
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+COMMUNITY_NOTES = ROOT / "data" / "community_notes.json"
+APP_HOSPITALS = ROOT / "app" / "hospitals.json"
+
+ALLOWED_CATEGORIES = {"contact_fix", "pin_fix", "closed", "wrong_unit", "other"}
+SUMMARY_MAX = 280
+DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+
+def parse_date(value: object, field: str, ctx: str, errors: list[str]) -> date | None:
+    if not isinstance(value, str) or not value.strip():
+        errors.append(f"{ctx}: {field} is required")
+        return None
+    if not DATE_RE.match(value):
+        errors.append(f"{ctx}: {field} must be YYYY-MM-DD")
+        return None
+    try:
+        return date.fromisoformat(value)
+    except ValueError:
+        errors.append(f"{ctx}: {field} must be YYYY-MM-DD")
+        return None
+
+
+def load_known_cnes(app_hospitals_path: Path) -> set[str]:
+    data = json.loads(app_hospitals_path.read_text(encoding="utf-8"))
+    if not isinstance(data, list):
+        raise ValueError(f"{app_hospitals_path} must be a JSON array")
+    return {str(row.get("cnes", "")).strip() for row in data if row.get("cnes")}
+
+
+def validate(
+    community_notes_path: Path = COMMUNITY_NOTES,
+    app_hospitals_path: Path = APP_HOSPITALS,
+) -> list[str]:
+    errors: list[str] = []
+
+    try:
+        data = json.loads(community_notes_path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        return [f"{community_notes_path}: cannot read JSON: {exc}"]
+
+    if not isinstance(data, dict):
+        return [f"{community_notes_path}: top-level value must be an object"]
+
+    parse_date(data.get("generated_at"), "generated_at", str(community_notes_path), errors)
+
+    notes = data.get("notes")
+    if not isinstance(notes, dict):
+        errors.append(f"{community_notes_path}: notes must be an object")
+        return errors
+
+    try:
+        known_cnes = load_known_cnes(app_hospitals_path)
+    except Exception as exc:
+        errors.append(f"{app_hospitals_path}: cannot load known CNES values: {exc}")
+        known_cnes = set()
+    if not known_cnes:
+        errors.append(f"{app_hospitals_path}: no CNES values found for reference checks")
+
+    for raw_cnes, entries in sorted(notes.items()):
+        cnes = str(raw_cnes).strip()
+        ctx = f"CNES {cnes or '?'}"
+        if not cnes:
+            errors.append("notes contains a blank CNES key")
+            continue
+        if not cnes.isdigit():
+            errors.append(f"{ctx}: CNES key must contain only digits")
+        if cnes not in known_cnes:
+            errors.append(f"{ctx}: CNES is not present in app/hospitals.json")
+        if not isinstance(entries, list) or not entries:
+            errors.append(f"{ctx}: value must be a non-empty list")
+            continue
+
+        for i, note in enumerate(entries, start=1):
+            nctx = f"{ctx} note {i}"
+            if not isinstance(note, dict):
+                errors.append(f"{nctx}: note must be an object")
+                continue
+
+            category = note.get("category")
+            if category not in ALLOWED_CATEGORIES:
+                errors.append(
+                    f"{nctx}: category must be one of {', '.join(sorted(ALLOWED_CATEGORIES))}"
+                )
+
+            reported_at = parse_date(note.get("reported_at"), "reported_at", nctx, errors)
+
+            summary = note.get("public_summary")
+            if not isinstance(summary, str) or not summary.strip():
+                errors.append(f"{nctx}: public_summary is required")
+            elif len(summary) > SUMMARY_MAX:
+                errors.append(f"{nctx}: public_summary exceeds {SUMMARY_MAX} characters")
+
+            expires_raw = note.get("expires_at")
+            if expires_raw not in (None, ""):
+                expires_at = parse_date(expires_raw, "expires_at", nctx, errors)
+                if reported_at and expires_at and expires_at <= reported_at:
+                    errors.append(f"{nctx}: expires_at must be after reported_at")
+
+            allowed_keys = {"category", "reported_at", "public_summary", "expires_at"}
+            unknown = sorted(set(note) - allowed_keys)
+            if unknown:
+                errors.append(f"{nctx}: unknown key(s): {', '.join(unknown)}")
+
+    return errors
+
+
+def main() -> int:
+    errors = validate()
+    if errors:
+        print(f"FAIL: {len(errors)} community note error(s)", file=sys.stderr)
+        for error in errors:
+            print(f"  - {error}", file=sys.stderr)
+        return 1
+    print(f"OK: community notes validated in {COMMUNITY_NOTES}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Adds `scripts/validate_community_notes.py` for the manually curated community-note source file.
- Validates generated/report dates, allowed categories, summary length, expiry ordering, unknown keys, and CNES references against `app/hospitals.json`.
- Runs the validator in both PR CI and the direct-to-main rebuild workflow used after Sheet publishes.

## Context
Community notes are an emergency-facing public layer generated from the SoroJá Sheet. CI previously validated the final `hospitals.json`, but malformed `data/community_notes.json` could still be published directly to `main` and rebuilt before a PR gate ever ran.

## Scope
This intentionally does not change:
- existing community-note content
- public rendering of relatos
- hospital data, overrides, or rebuild semantics
- the Google Sheet publishing script

## Testing
- `.venv/bin/python -m pytest scripts/tests/ -v`
- `.venv/bin/python scripts/validate_community_notes.py`
- `.venv/bin/python scripts/canonicalize_antivenoms.py --self-test`
- `.venv/bin/python scripts/validate_hospitals_json.py app/hospitals.json`
- `git diff --check -- .github/workflows/ci.yml .github/workflows/rebuild-hospitals-on-override.yml scripts/validate_community_notes.py scripts/tests/test_validate_community_notes.py`

## AI assistance
This PR was prepared with AI assistance. I personally reviewed the final diff, scope, and validation, and I take responsibility for the changes.