### PR TITLE
ci: validate location overrides

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,5 +30,8 @@ jobs:
       - name: Pytest suite
         run: python3 -m pytest scripts/tests/ -v
 
+      - name: Validate location overrides
+        run: python3 scripts/validate_location_overrides.py
+
       - name: Validate app/hospitals.json schema
         run: python3 scripts/validate_hospitals_json.py app/hospitals.json

--- a/.github/workflows/rebuild-hospitals-on-override.yml
+++ b/.github/workflows/rebuild-hospitals-on-override.yml
@@ -26,6 +26,9 @@ jobs:
         with:
           python-version: '3.11'
 
+      - name: Validate location overrides
+        run: python3 scripts/validate_location_overrides.py
+
       - name: Rebuild hospitals.json
         run: python3 scripts/build_app_hospitals_json.py
 

--- a/scripts/tests/test_validate_location_overrides.py
+++ b/scripts/tests/test_validate_location_overrides.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import validate_location_overrides as validator  # noqa: E402
+
+
+def write_json(path: Path, data: object) -> None:
+    path.write_text(json.dumps(data), encoding="utf-8")
+
+
+def write_master(path: Path, cnes_values: list[str], publish_policy: str = "publish") -> None:
+    with path.open("w", encoding="utf-8", newline="") as fh:
+        writer = csv.DictWriter(fh, fieldnames=["row_id", "cnes", "publish_policy"])
+        writer.writeheader()
+        for i, cnes in enumerate(cnes_values, start=1):
+            writer.writerow(
+                {"row_id": f"SP_{i:04d}", "cnes": cnes, "publish_policy": publish_policy}
+            )
+
+
+def test_valid_coordinate_override_passes(tmp_path: Path):
+    overrides = tmp_path / "location_overrides.json"
+    master = tmp_path / "master.csv"
+    write_master(master, ["123"])
+    write_json(
+        overrides,
+        {
+            "123": {
+                "reason": "Pin verified manually.",
+                "verified_on": "2026-06-22",
+                "lat": -23.55,
+                "lng": -46.63,
+            }
+        },
+    )
+
+    assert validator.validate(overrides, master) == []
+
+
+def test_valid_hide_override_passes(tmp_path: Path):
+    overrides = tmp_path / "location_overrides.json"
+    master = tmp_path / "master.csv"
+    write_master(master, ["123"])
+    write_json(
+        overrides,
+        {
+            "123": {
+                "reason": "Source row is unsafe to publish.",
+                "verified_on": "2026-06-22",
+                "hide": True,
+            }
+        },
+    )
+
+    assert validator.validate(overrides, master) == []
+
+
+def test_rejects_unknown_cnes_and_unknown_keys(tmp_path: Path):
+    overrides = tmp_path / "location_overrides.json"
+    master = tmp_path / "master.csv"
+    write_master(master, ["123"])
+    write_json(
+        overrides,
+        {
+            "999": {
+                "reason": "Pin verified manually.",
+                "verified_on": "2026-06-22",
+                "lat": -23.55,
+                "lng": -46.63,
+                "raw_report": "do not publish",
+            }
+        },
+    )
+
+    errors = validator.validate(overrides, master)
+
+    assert "CNES 999: CNES is not publishable in build/master_geocoded_patched_v1.csv" in errors
+    assert "CNES 999: unknown key(s): raw_report" in errors
+
+
+def test_rejects_non_publishable_cnes(tmp_path: Path):
+    overrides = tmp_path / "location_overrides.json"
+    master = tmp_path / "master.csv"
+    write_master(master, ["123"], publish_policy="hide_muni_mismatch")
+    write_json(
+        overrides,
+        {
+            "123": {
+                "reason": "Pin verified manually.",
+                "verified_on": "2026-06-22",
+                "lat": -23.55,
+                "lng": -46.63,
+            }
+        },
+    )
+
+    errors = validator.validate(overrides, master)
+
+    assert any("no publishable CNES values found for reference checks" in error for error in errors)
+    assert "CNES 123: CNES is not publishable in build/master_geocoded_patched_v1.csv" in errors
+
+
+def test_rejects_partial_or_out_of_range_coordinates(tmp_path: Path):
+    overrides = tmp_path / "location_overrides.json"
+    master = tmp_path / "master.csv"
+    write_master(master, ["123", "456"])
+    write_json(
+        overrides,
+        {
+            "123": {
+                "reason": "Missing lng.",
+                "verified_on": "2026-06-22",
+                "lat": -23.55,
+            },
+            "456": {
+                "reason": "Outside Brazil.",
+                "verified_on": "2026-06-22",
+                "lat": 40.0,
+                "lng": -46.63,
+            },
+        },
+    )
+
+    errors = validator.validate(overrides, master)
+
+    assert "CNES 123: lat and lng must be provided together" in errors
+    assert "CNES 456: lat/lng (40.0, -46.63) outside Brazil bbox" in errors
+
+
+def test_rejects_bad_metadata_and_no_action(tmp_path: Path):
+    overrides = tmp_path / "location_overrides.json"
+    master = tmp_path / "master.csv"
+    write_master(master, ["123"])
+    write_json(
+        overrides,
+        {
+            "123": {
+                "reason": "",
+                "verified_on": "2026-W26-1",
+                "hide": "true",
+            }
+        },
+    )
+
+    errors = validator.validate(overrides, master)
+
+    assert "CNES 123: reason is required" in errors
+    assert "CNES 123: verified_on must be YYYY-MM-DD" in errors
+    assert "CNES 123: hide must be a boolean" in errors
+    assert "CNES 123: override must set hide, lat/lng, address, or note" in errors
+
+
+def test_rejects_empty_reference_cnes_set(tmp_path: Path):
+    overrides = tmp_path / "location_overrides.json"
+    master = tmp_path / "master.csv"
+    write_master(master, [])
+    write_json(
+        overrides,
+        {
+            "123": {
+                "reason": "Pin verified manually.",
+                "verified_on": "2026-06-22",
+                "lat": -23.55,
+                "lng": -46.63,
+            }
+        },
+    )
+
+    errors = validator.validate(overrides, master)
+
+    assert any("no publishable CNES values found for reference checks" in error for error in errors)
+    assert "CNES 123: CNES is not publishable in build/master_geocoded_patched_v1.csv" in errors

--- a/scripts/validate_location_overrides.py
+++ b/scripts/validate_location_overrides.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Validate data/location_overrides.json before rebuilding public data."""
+
+from __future__ import annotations
+
+import csv
+from datetime import date
+import json
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+OVERRIDES = ROOT / "data" / "location_overrides.json"
+MASTER = ROOT / "build" / "master_geocoded_patched_v1.csv"
+
+LAT_MIN, LAT_MAX = -34.0, 5.5
+LNG_MIN, LNG_MAX = -74.5, -34.5
+DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+ALLOWED_KEYS = {"reason", "verified_on", "lat", "lng", "address", "note", "hide"}
+
+
+def parse_date(value: object, field: str, ctx: str, errors: list[str]) -> date | None:
+    if not isinstance(value, str) or not value.strip():
+        errors.append(f"{ctx}: {field} is required")
+        return None
+    if not DATE_RE.match(value):
+        errors.append(f"{ctx}: {field} must be YYYY-MM-DD")
+        return None
+    try:
+        return date.fromisoformat(value)
+    except ValueError:
+        errors.append(f"{ctx}: {field} must be a valid calendar date")
+        return None
+
+
+def load_publishable_cnes(master_path: Path) -> set[str]:
+    with master_path.open(encoding="utf-8", newline="") as fh:
+        reader = csv.DictReader(fh)
+        return {
+            str(row.get("cnes", "")).strip()
+            for row in reader
+            if row.get("cnes") and (row.get("publish_policy") or "").strip() == "publish"
+        }
+
+
+def validate(
+    overrides_path: Path = OVERRIDES,
+    master_path: Path = MASTER,
+) -> list[str]:
+    errors: list[str] = []
+
+    try:
+        data = json.loads(overrides_path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        return [f"{overrides_path}: cannot read JSON: {exc}"]
+
+    if not isinstance(data, dict):
+        return [f"{overrides_path}: top-level value must be an object"]
+
+    try:
+        known_cnes = load_publishable_cnes(master_path)
+    except Exception as exc:
+        errors.append(f"{master_path}: cannot load known CNES values: {exc}")
+        known_cnes = set()
+    if not known_cnes:
+        errors.append(f"{master_path}: no publishable CNES values found for reference checks")
+
+    for raw_cnes, override in sorted(data.items()):
+        cnes = str(raw_cnes).strip()
+        ctx = f"CNES {cnes or '?'}"
+        if not cnes:
+            errors.append("overrides contains a blank CNES key")
+            continue
+        if not cnes.isdigit():
+            errors.append(f"{ctx}: CNES key must contain only digits")
+        if cnes not in known_cnes:
+            errors.append(
+                f"{ctx}: CNES is not publishable in build/master_geocoded_patched_v1.csv"
+            )
+        if not isinstance(override, dict):
+            errors.append(f"{ctx}: override must be an object")
+            continue
+
+        unknown = sorted(set(override) - ALLOWED_KEYS)
+        if unknown:
+            errors.append(f"{ctx}: unknown key(s): {', '.join(unknown)}")
+
+        reason = override.get("reason")
+        if not isinstance(reason, str) or not reason.strip():
+            errors.append(f"{ctx}: reason is required")
+
+        parse_date(override.get("verified_on"), "verified_on", ctx, errors)
+
+        hide = override.get("hide")
+        if "hide" in override and not isinstance(hide, bool):
+            errors.append(f"{ctx}: hide must be a boolean")
+
+        has_lat = "lat" in override
+        has_lng = "lng" in override
+        if has_lat != has_lng:
+            errors.append(f"{ctx}: lat and lng must be provided together")
+        if has_lat and has_lng:
+            try:
+                lat = float(override.get("lat"))
+                lng = float(override.get("lng"))
+            except (TypeError, ValueError):
+                errors.append(f"{ctx}: lat/lng must be numeric")
+            else:
+                if not (LAT_MIN <= lat <= LAT_MAX and LNG_MIN <= lng <= LNG_MAX):
+                    errors.append(f"{ctx}: lat/lng ({lat}, {lng}) outside Brazil bbox")
+
+        for field in ("address", "note"):
+            if field in override and (
+                not isinstance(override[field], str) or not override[field].strip()
+            ):
+                errors.append(f"{ctx}: {field} must be a non-empty string when set")
+
+        changes_data = bool(hide is True or has_lat or "address" in override or "note" in override)
+        if not changes_data:
+            errors.append(f"{ctx}: override must set hide, lat/lng, address, or note")
+
+    return errors
+
+
+def main() -> int:
+    errors = validate()
+    if errors:
+        print(f"FAIL: {len(errors)} location override error(s)", file=sys.stderr)
+        for error in errors:
+            print(f"  - {error}", file=sys.stderr)
+        return 1
+    print(f"OK: location overrides validated in {OVERRIDES}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Adds `scripts/validate_location_overrides.py` for the manually curated override source file.
- Validates reason/date metadata, allowed keys, paired coordinates, Brazil bounds, `hide` typing, and actionable override fields.
- Checks override CNES values against publishable rows in `build/master_geocoded_patched_v1.csv`, matching `build_app_hospitals_json.py` semantics.
- Runs the validator in both PR CI and the direct-to-main rebuild workflow used after Sheet publishes.

## Context
Location overrides affect public pins, hidden records, and warning notes. Invalid or inert overrides could be committed by the Sheet publishing flow and rebuilt into public artifacts without a targeted source-file gate.

## Scope
This intentionally does not change:
- existing coordinates, notes, addresses, or hidden records
- override application semantics in `build_app_hospitals_json.py`
- public hospital data
- the Google Sheet publishing script

## Testing
- `.venv/bin/python -m pytest scripts/tests/ -v`
- `.venv/bin/python scripts/validate_location_overrides.py`
- `.venv/bin/python scripts/canonicalize_antivenoms.py --self-test`
- `.venv/bin/python scripts/validate_hospitals_json.py app/hospitals.json`
- `git diff --check -- .github/workflows/ci.yml .github/workflows/rebuild-hospitals-on-override.yml scripts/validate_location_overrides.py scripts/tests/test_validate_location_overrides.py`

## AI assistance
This PR was prepared with AI assistance. I personally reviewed the final diff, scope, and validation, and I take responsibility for the changes.