### PR TITLE
ci(workflows): split checks and add security validation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/check-ms-updates.yml
+++ b/.github/workflows/check-ms-updates.yml
@@ -9,7 +9,7 @@ on:
   schedule:
     # Todo dia às 09:00 UTC (06:00 BRT).
     - cron: "0 9 * * *"
-  workflow_dispatch: {}  # permite rodar manualmente pela aba Actions
+  workflow_dispatch: {} # permite rodar manualmente pela aba Actions
 
 permissions:
   issues: write
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.13"
 
       - name: Install dependencies
         run: pip install requests beautifulsoup4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ permissions:
   contents: read
 
 jobs:
-  tests:
+  canonicalizer:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -19,16 +19,73 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
-
-      - name: Install pytest
-        run: pip install pytest
+          python-version: "3.13"
 
       - name: Canonicalizer self-test
         run: python3 scripts/canonicalize_antivenoms.py --self-test
 
+  unit-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install pytest
+        run: pip install pytest
+
       - name: Pytest suite
-        run: python3 -m pytest scripts/tests/ -v
+        run: python3 -m pytest scripts/tests/ -v --ignore=scripts/tests/test_security_config.py
+
+  dataset-validation:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
 
       - name: Validate app/hospitals.json schema
         run: python3 scripts/validate_hospitals_json.py app/hospitals.json
+
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Prettier check
+        run: npm run format:check
+
+  security-config:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install pytest
+        run: pip install pytest
+
+      - name: Security configuration tests
+        run: python3 -m pytest scripts/tests/test_security_config.py -v

--- a/.github/workflows/rebuild-hospitals-on-override.yml
+++ b/.github/workflows/rebuild-hospitals-on-override.yml
@@ -9,8 +9,8 @@ on:
   push:
     branches: [main]
     paths:
-      - 'data/location_overrides.json'
-      - 'data/community_notes.json'
+      - "data/location_overrides.json"
+      - "data/community_notes.json"
   workflow_dispatch: {}
 
 permissions:
@@ -24,7 +24,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: "3.13"
 
       - name: Rebuild hospitals.json
         run: python3 scripts/build_app_hospitals_json.py

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,14 @@
+.git/
+.venv/
+.venvs/
+.pytest_cache/
+node_modules/
+
+build/
+reports/
+extracted/
+data/manual_triage/
+data/dates_status.md
+
+hospitals.json
+app/hospitals.json

--- a/PDF_DOWNLOAD_INSTRUCTIONS.md
+++ b/PDF_DOWNLOAD_INSTRUCTIONS.md
@@ -15,11 +15,13 @@ Create the folder `data/pdfs/` in this project if it doesn't already exist.
 ## Step 2: Navigate to the index page
 
 Go to:
+
 ```
 https://www.gov.br/saude/pt-br/assuntos/saude-de-a-a-z/a/animais-peconhentos/hospitais-de-referencia
 ```
 
 This page lists all Brazilian states with links to their PESA hospital PDFs. The page is **paginated** — there are 2 pages:
+
 - Page 1: `?b_start:int=0` (default)
 - Page 2: `?b_start:int=15`
 
@@ -28,6 +30,7 @@ This page lists all Brazilian states with links to their PESA hospital PDFs. The
 ## Step 3: Download all 27 state PDFs
 
 Each state has a PDF download link. The download URL pattern is:
+
 ```
 https://www.gov.br/saude/pt-br/assuntos/saude-de-a-a-z/a/animais-peconhentos/hospitais-de-referencia/{state-slug}/@@download/file
 ```
@@ -36,35 +39,35 @@ Download each PDF and save it with the filename `{state-slug}.pdf`.
 
 Here are all 27 states with their slugs and direct download URLs:
 
-| # | State | Slug | Download URL |
-|---|-------|------|-------------|
-| 1 | Acre | `acre` | `https://www.gov.br/saude/pt-br/assuntos/saude-de-a-a-z/a/animais-peconhentos/hospitais-de-referencia/acre/@@download/file` |
-| 2 | Alagoas | `alagoas` | `https://www.gov.br/saude/pt-br/assuntos/saude-de-a-a-z/a/animais-peconhentos/hospitais-de-referencia/alagoas/@@download/file` |
-| 3 | Amapa | `amapa` | `https://www.gov.br/saude/pt-br/assuntos/saude-de-a-a-z/a/animais-peconhentos/hospitais-de-referencia/amapa/@@download/file` |
-| 4 | Amazonas | `amazonas` | `https://www.gov.br/saude/pt-br/assuntos/saude-de-a-a-z/a/animais-peconhentos/hospitais-de-referencia/amazonas/@@download/file` |
-| 5 | Bahia | `bahia` | `https://www.gov.br/saude/pt-br/assuntos/saude-de-a-a-z/a/animais-peconhentos/hospitais-de-referencia/bahia/@@download/file` |
-| 6 | Ceara | `ceara` | `https://www.gov.br/saude/pt-br/assuntos/saude-de-a-a-z/a/animais-peconhentos/hospitais-de-referencia/ceara/@@download/file` |
-| 7 | Distrito Federal | `distrito-federal` | `https://www.gov.br/saude/pt-br/assuntos/saude-de-a-a-z/a/animais-peconhentos/hospitais-de-referencia/distrito-federal/@@download/file` |
-| 8 | Espirito Santo | `espirito-santo` | `https://www.gov.br/saude/pt-br/assuntos/saude-de-a-a-z/a/animais-peconhentos/hospitais-de-referencia/espirito-santo/@@download/file` |
-| 9 | Goias | `goias` | `https://www.gov.br/saude/pt-br/assuntos/saude-de-a-a-z/a/animais-peconhentos/hospitais-de-referencia/goias/@@download/file` |
-| 10 | Maranhao | `maranhao` | `https://www.gov.br/saude/pt-br/assuntos/saude-de-a-a-z/a/animais-peconhentos/hospitais-de-referencia/maranhao/@@download/file` |
-| 11 | Mato Grosso | `mato-grosso` | `https://www.gov.br/saude/pt-br/assuntos/saude-de-a-a-z/a/animais-peconhentos/hospitais-de-referencia/mato-grosso/@@download/file` |
-| 12 | Mato Grosso do Sul | `mato-grosso-do-sul` | `https://www.gov.br/saude/pt-br/assuntos/saude-de-a-a-z/a/animais-peconhentos/hospitais-de-referencia/mato-grosso-do-sul/@@download/file` |
-| 13 | Minas Gerais | `minas-gerais` | `https://www.gov.br/saude/pt-br/assuntos/saude-de-a-a-z/a/animais-peconhentos/hospitais-de-referencia/minas-gerais/@@download/file` |
-| 14 | Para | `para` | `https://www.gov.br/saude/pt-br/assuntos/saude-de-a-a-z/a/animais-peconhentos/hospitais-de-referencia/para/@@download/file` |
-| 15 | Paraiba | `paraiba` | `https://www.gov.br/saude/pt-br/assuntos/saude-de-a-a-z/a/animais-peconhentos/hospitais-de-referencia/paraiba/@@download/file` |
-| 16 | Parana | `parana` | `https://www.gov.br/saude/pt-br/assuntos/saude-de-a-a-z/a/animais-peconhentos/hospitais-de-referencia/parana/@@download/file` |
-| 17 | Pernambuco | `pernambuco` | `https://www.gov.br/saude/pt-br/assuntos/saude-de-a-a-z/a/animais-peconhentos/hospitais-de-referencia/pernambuco/@@download/file` |
-| 18 | Piaui | `piaui` | `https://www.gov.br/saude/pt-br/assuntos/saude-de-a-a-z/a/animais-peconhentos/hospitais-de-referencia/piaui/@@download/file` |
-| 19 | Rio de Janeiro | `rio-de-janeiro` | `https://www.gov.br/saude/pt-br/assuntos/saude-de-a-a-z/a/animais-peconhentos/hospitais-de-referencia/rio-de-janeiro/@@download/file` |
-| 20 | Rio Grande do Norte | `rio-grande-do-norte` | `https://www.gov.br/saude/pt-br/assuntos/saude-de-a-a-z/a/animais-peconhentos/hospitais-de-referencia/rio-grande-do-norte/@@download/file` |
-| 21 | Rio Grande do Sul | `rio-grande-do-sul` | `https://www.gov.br/saude/pt-br/assuntos/saude-de-a-a-z/a/animais-peconhentos/hospitais-de-referencia/rio-grande-do-sul/@@download/file` |
-| 22 | Rondonia | `rondonia` | `https://www.gov.br/saude/pt-br/assuntos/saude-de-a-a-z/a/animais-peconhentos/hospitais-de-referencia/rondonia/@@download/file` |
-| 23 | Roraima | `roraima` | `https://www.gov.br/saude/pt-br/assuntos/saude-de-a-a-z/a/animais-peconhentos/hospitais-de-referencia/roraima/@@download/file` |
-| 24 | Santa Catarina | `santa-catarina` | `https://www.gov.br/saude/pt-br/assuntos/saude-de-a-a-z/a/animais-peconhentos/hospitais-de-referencia/santa-catarina/@@download/file` |
-| 25 | Sao Paulo | `sao-paulo` | `https://www.gov.br/saude/pt-br/assuntos/saude-de-a-a-z/a/animais-peconhentos/hospitais-de-referencia/sao-paulo/@@download/file` |
-| 26 | Sergipe | `sergipe` | `https://www.gov.br/saude/pt-br/assuntos/saude-de-a-a-z/a/animais-peconhentos/hospitais-de-referencia/sergipe/@@download/file` |
-| 27 | Tocantins | `tocantins` | `https://www.gov.br/saude/pt-br/assuntos/saude-de-a-a-z/a/animais-peconhentos/hospitais-de-referencia/tocantins/@@download/file` |
+| #   | State               | Slug                  | Download URL                                                                                                                               |
+| --- | ------------------- | --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| 1   | Acre                | `acre`                | `https://www.gov.br/saude/pt-br/assuntos/saude-de-a-a-z/a/animais-peconhentos/hospitais-de-referencia/acre/@@download/file`                |
+| 2   | Alagoas             | `alagoas`             | `https://www.gov.br/saude/pt-br/assuntos/saude-de-a-a-z/a/animais-peconhentos/hospitais-de-referencia/alagoas/@@download/file`             |
+| 3   | Amapa               | `amapa`               | `https://www.gov.br/saude/pt-br/assuntos/saude-de-a-a-z/a/animais-peconhentos/hospitais-de-referencia/amapa/@@download/file`               |
+| 4   | Amazonas            | `amazonas`            | `https://www.gov.br/saude/pt-br/assuntos/saude-de-a-a-z/a/animais-peconhentos/hospitais-de-referencia/amazonas/@@download/file`            |
+| 5   | Bahia               | `bahia`               | `https://www.gov.br/saude/pt-br/assuntos/saude-de-a-a-z/a/animais-peconhentos/hospitais-de-referencia/bahia/@@download/file`               |
+| 6   | Ceara               | `ceara`               | `https://www.gov.br/saude/pt-br/assuntos/saude-de-a-a-z/a/animais-peconhentos/hospitais-de-referencia/ceara/@@download/file`               |
+| 7   | Distrito Federal    | `distrito-federal`    | `https://www.gov.br/saude/pt-br/assuntos/saude-de-a-a-z/a/animais-peconhentos/hospitais-de-referencia/distrito-federal/@@download/file`    |
+| 8   | Espirito Santo      | `espirito-santo`      | `https://www.gov.br/saude/pt-br/assuntos/saude-de-a-a-z/a/animais-peconhentos/hospitais-de-referencia/espirito-santo/@@download/file`      |
+| 9   | Goias               | `goias`               | `https://www.gov.br/saude/pt-br/assuntos/saude-de-a-a-z/a/animais-peconhentos/hospitais-de-referencia/goias/@@download/file`               |
+| 10  | Maranhao            | `maranhao`            | `https://www.gov.br/saude/pt-br/assuntos/saude-de-a-a-z/a/animais-peconhentos/hospitais-de-referencia/maranhao/@@download/file`            |
+| 11  | Mato Grosso         | `mato-grosso`         | `https://www.gov.br/saude/pt-br/assuntos/saude-de-a-a-z/a/animais-peconhentos/hospitais-de-referencia/mato-grosso/@@download/file`         |
+| 12  | Mato Grosso do Sul  | `mato-grosso-do-sul`  | `https://www.gov.br/saude/pt-br/assuntos/saude-de-a-a-z/a/animais-peconhentos/hospitais-de-referencia/mato-grosso-do-sul/@@download/file`  |
+| 13  | Minas Gerais        | `minas-gerais`        | `https://www.gov.br/saude/pt-br/assuntos/saude-de-a-a-z/a/animais-peconhentos/hospitais-de-referencia/minas-gerais/@@download/file`        |
+| 14  | Para                | `para`                | `https://www.gov.br/saude/pt-br/assuntos/saude-de-a-a-z/a/animais-peconhentos/hospitais-de-referencia/para/@@download/file`                |
+| 15  | Paraiba             | `paraiba`             | `https://www.gov.br/saude/pt-br/assuntos/saude-de-a-a-z/a/animais-peconhentos/hospitais-de-referencia/paraiba/@@download/file`             |
+| 16  | Parana              | `parana`              | `https://www.gov.br/saude/pt-br/assuntos/saude-de-a-a-z/a/animais-peconhentos/hospitais-de-referencia/parana/@@download/file`              |
+| 17  | Pernambuco          | `pernambuco`          | `https://www.gov.br/saude/pt-br/assuntos/saude-de-a-a-z/a/animais-peconhentos/hospitais-de-referencia/pernambuco/@@download/file`          |
+| 18  | Piaui               | `piaui`               | `https://www.gov.br/saude/pt-br/assuntos/saude-de-a-a-z/a/animais-peconhentos/hospitais-de-referencia/piaui/@@download/file`               |
+| 19  | Rio de Janeiro      | `rio-de-janeiro`      | `https://www.gov.br/saude/pt-br/assuntos/saude-de-a-a-z/a/animais-peconhentos/hospitais-de-referencia/rio-de-janeiro/@@download/file`      |
+| 20  | Rio Grande do Norte | `rio-grande-do-norte` | `https://www.gov.br/saude/pt-br/assuntos/saude-de-a-a-z/a/animais-peconhentos/hospitais-de-referencia/rio-grande-do-norte/@@download/file` |
+| 21  | Rio Grande do Sul   | `rio-grande-do-sul`   | `https://www.gov.br/saude/pt-br/assuntos/saude-de-a-a-z/a/animais-peconhentos/hospitais-de-referencia/rio-grande-do-sul/@@download/file`   |
+| 22  | Rondonia            | `rondonia`            | `https://www.gov.br/saude/pt-br/assuntos/saude-de-a-a-z/a/animais-peconhentos/hospitais-de-referencia/rondonia/@@download/file`            |
+| 23  | Roraima             | `roraima`             | `https://www.gov.br/saude/pt-br/assuntos/saude-de-a-a-z/a/animais-peconhentos/hospitais-de-referencia/roraima/@@download/file`             |
+| 24  | Santa Catarina      | `santa-catarina`      | `https://www.gov.br/saude/pt-br/assuntos/saude-de-a-a-z/a/animais-peconhentos/hospitais-de-referencia/santa-catarina/@@download/file`      |
+| 25  | Sao Paulo           | `sao-paulo`           | `https://www.gov.br/saude/pt-br/assuntos/saude-de-a-a-z/a/animais-peconhentos/hospitais-de-referencia/sao-paulo/@@download/file`           |
+| 26  | Sergipe             | `sergipe`             | `https://www.gov.br/saude/pt-br/assuntos/saude-de-a-a-z/a/animais-peconhentos/hospitais-de-referencia/sergipe/@@download/file`             |
+| 27  | Tocantins           | `tocantins`           | `https://www.gov.br/saude/pt-br/assuntos/saude-de-a-a-z/a/animais-peconhentos/hospitais-de-referencia/tocantins/@@download/file`           |
 
 ---
 

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -66,4 +66,4 @@ O site é servido exclusivamente via HTTPS. O código-fonte é aberto e auditáv
 
 ---
 
-*Para sugestões ou reporte de problemas nesta Política, abra uma issue no repositório ou escreva para o contato do item 1.*
+_Para sugestões ou reporte de problemas nesta Política, abra uma issue no repositório ou escreva para o contato do item 1._

--- a/TERMS.md
+++ b/TERMS.md
@@ -67,4 +67,4 @@ Para eventuais questões judiciais, fica eleito o foro da Comarca de São Paulo,
 
 ---
 
-*Dúvidas ou problemas? Abra uma issue em https://github.com/educrvz/sos-antiveneno/issues.*
+_Dúvidas ou problemas? Abra uma issue em https://github.com/educrvz/sos-antiveneno/issues._

--- a/docs/PROCESS.md
+++ b/docs/PROCESS.md
@@ -131,7 +131,7 @@ For each new/updated UF, prompt Claude Code with something like:
 > Re-extract `Docs Estado/BA_20260105.pdf` to `extracted/BA.new.json`.
 > Follow the schema in `extracted/AC.json`: one object per hospital row
 > with keys `state, municipality, health_unit_name, address, phones_raw,
-> cnes, antivenoms_raw, source_notes`. Preserve source typos, inherited
+cnes, antivenoms_raw, source_notes`. Preserve source typos, inherited
 > municipality cells, and anomalous CNES values; flag each in
 > `source_notes`. Use compact one-line JSON per record.
 
@@ -366,19 +366,19 @@ JSON still agree on row identity/counts and published CNES values.
 
 Field mapping:
 
-| App field       | Source column              | Transform                                                                 |
-|-----------------|---------------------------|---------------------------------------------------------------------------|
-| `hospital_name` | `health_unit_name`        | trim/collapse whitespace                                                  |
-| `state`         | `source_state_abbr`       | 2-letter UF                                                               |
-| `state_name`    | `state`                   | title-cased from upper-case source (`ACRE` → `Acre`, `SÃO PAULO` → `São Paulo`) |
-| `city`          | `municipality`            | raw                                                                       |
-| `lat`, `lng`    | `lat`, `lng`              | `float()`; row dropped if either is blank                                 |
-| `address`       | `address`                 | raw                                                                       |
-| `antivenoms`    | `antivenoms_raw`          | split on `\|`, drop blanks → string array                                 |
-| `phones`        | `phones_raw`              | split on `/` or `,`; drop placeholders (`não disponível`, `sem contato`, `****`, `-`, <4 chars) → string array |
-| `source_date`   | `source_state_file`       | ISO `YYYY-MM-DD` parsed from `Docs Estado/{UF}_YYYYMMDD.pdf`              |
-| `cnes`          | `cnes`                    | string                                                                    |
-| `geocode_tier`  | `location_type`           | `ROOFTOP`→1, `RANGE_INTERPOLATED`→2, `GEOMETRIC_CENTER`→3, `APPROXIMATE`→3; the app renders tier 3 with a leading `~` on the distance |
+| App field       | Source column       | Transform                                                                                                                             |
+| --------------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| `hospital_name` | `health_unit_name`  | trim/collapse whitespace                                                                                                              |
+| `state`         | `source_state_abbr` | 2-letter UF                                                                                                                           |
+| `state_name`    | `state`             | title-cased from upper-case source (`ACRE` → `Acre`, `SÃO PAULO` → `São Paulo`)                                                       |
+| `city`          | `municipality`      | raw                                                                                                                                   |
+| `lat`, `lng`    | `lat`, `lng`        | `float()`; row dropped if either is blank                                                                                             |
+| `address`       | `address`           | raw                                                                                                                                   |
+| `antivenoms`    | `antivenoms_raw`    | split on `\|`, drop blanks → string array                                                                                             |
+| `phones`        | `phones_raw`        | split on `/` or `,`; drop placeholders (`não disponível`, `sem contato`, `****`, `-`, <4 chars) → string array                        |
+| `source_date`   | `source_state_file` | ISO `YYYY-MM-DD` parsed from `Docs Estado/{UF}_YYYYMMDD.pdf`                                                                          |
+| `cnes`          | `cnes`              | string                                                                                                                                |
+| `geocode_tier`  | `location_type`     | `ROOFTOP`→1, `RANGE_INTERPOLATED`→2, `GEOMETRIC_CENTER`→3, `APPROXIMATE`→3; the app renders tier 3 with a leading `~` on the distance |
 
 **Stop and investigate if** the output row count deviates substantially
 from the `publish_ready_v1.csv` row count — the only legitimate reason to
@@ -411,7 +411,7 @@ Verify:
 
 ## Fixing a reported bad pin or address
 
-For one-off user reports (wrong pin *or* wrong address on a specific
+For one-off user reports (wrong pin _or_ wrong address on a specific
 hospital), you don't need the PDF pipeline. The **SoroJá Overrides** Google
 Sheet layers per-`cnes` corrections on top of `hospitals.json`. The override
 file at [`data/location_overrides.json`](../data/location_overrides.json) is
@@ -468,7 +468,7 @@ paste-in plus setup instructions (required script properties:
 Community-sourced relatos that surface "the official Ministry of Health
 data is wrong" without mutating any official field. They render as a
 distinct amber callout on each hospital card, dated, with the standing
-disclaimer *"Informação não confirmada pelo Ministério da Saúde."*
+disclaimer _"Informação não confirmada pelo Ministério da Saúde."_
 
 **Source:** the **Community Notes** tab in the same overrides Google Sheet.
 One row per relato; multiple rows for the same CNES become an array of
@@ -488,7 +488,7 @@ validator enforces the length cap; the no-PII discipline is enforced by
 convention.
 
 **Publishing flow:** add rows in the Community Notes tab → menu
-*SoroJá → Publicar relatos da comunidade* → Apps Script writes
+_SoroJá → Publicar relatos da comunidade_ → Apps Script writes
 `data/community_notes.json` to GitHub → the rebuild workflow regenerates
 `hospitals.json` with notes attached inline → Vercel deploys.
 
@@ -530,17 +530,17 @@ then re-run stage 11. (A dedicated promotion script is a future ticket.)
 
 ## Appendix C — the 10-stage report map
 
-| Stage | Report                                                                            |
-|-------|-----------------------------------------------------------------------------------|
-| 01    | [`reports/01_inventory.md`](../reports/01_inventory.md)                            |
-| 02    | [`reports/02_schema_audit.md`](../reports/02_schema_audit.md)                      |
-| 03    | [`reports/03_merge_summary.md`](../reports/03_merge_summary.md)                    |
-| 04    | [`reports/04_normalization_summary.md`](../reports/04_normalization_summary.md)    |
-| 05    | [`reports/05_pre_geocode_qaqc.md`](../reports/05_pre_geocode_qaqc.md)              |
-| 06    | [`reports/06_geocode_smoke_test.md`](../reports/06_geocode_smoke_test.md)          |
-| 07    | [`reports/07_geocode_full_run.md`](../reports/07_geocode_full_run.md)              |
-| 08    | [`reports/08_geocode_review_summary_v3.md`](../reports/08_geocode_review_summary_v3.md) + [`v2 → v3 diff`](../reports/08_geocode_review_diff_v2_to_v3.md) |
+| Stage | Report                                                                                                                                                                          |
+| ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 01    | [`reports/01_inventory.md`](../reports/01_inventory.md)                                                                                                                         |
+| 02    | [`reports/02_schema_audit.md`](../reports/02_schema_audit.md)                                                                                                                   |
+| 03    | [`reports/03_merge_summary.md`](../reports/03_merge_summary.md)                                                                                                                 |
+| 04    | [`reports/04_normalization_summary.md`](../reports/04_normalization_summary.md)                                                                                                 |
+| 05    | [`reports/05_pre_geocode_qaqc.md`](../reports/05_pre_geocode_qaqc.md)                                                                                                           |
+| 06    | [`reports/06_geocode_smoke_test.md`](../reports/06_geocode_smoke_test.md)                                                                                                       |
+| 07    | [`reports/07_geocode_full_run.md`](../reports/07_geocode_full_run.md)                                                                                                           |
+| 08    | [`reports/08_geocode_review_summary_v3.md`](../reports/08_geocode_review_summary_v3.md) + [`v2 → v3 diff`](../reports/08_geocode_review_diff_v2_to_v3.md)                       |
 | 09a   | [`reports/09a_high_risk_exception_summary.md`](../reports/09a_high_risk_exception_summary.md) + [`09a_high_risk_source_context.md`](../reports/09a_high_risk_source_context.md) |
-| 09b   | [`reports/09b_high_risk_repair_summary.md`](../reports/09b_high_risk_repair_summary.md) |
-| 09c   | [`reports/09c_apply_repairs_summary.md`](../reports/09c_apply_repairs_summary.md)  |
-| 10    | [`reports/10_google_sheets_export_summary.md`](../reports/10_google_sheets_export_summary.md) + [`import guide`](../reports/10_google_sheets_import_guide.md) |
+| 09b   | [`reports/09b_high_risk_repair_summary.md`](../reports/09b_high_risk_repair_summary.md)                                                                                         |
+| 09c   | [`reports/09c_apply_repairs_summary.md`](../reports/09c_apply_repairs_summary.md)                                                                                               |
+| 10    | [`reports/10_google_sheets_export_summary.md`](../reports/10_google_sheets_export_summary.md) + [`import guide`](../reports/10_google_sheets_import_guide.md)                   |

--- a/docs/community-reports-plan.md
+++ b/docs/community-reports-plan.md
@@ -57,7 +57,7 @@ Reviewing the full Bug Reports database (resolved + open) and the Improvements p
 
 **Feature suggestions** (multiple convergent signals on UX gaps):
 
-- Emergency-order popup (community-sourced medical guidance): *"1) Ligar SAMU/bombeiros. 2) Ligar CIATox. 3) Só depois ir ao local com soro."* — this is medically more correct than the generic "ligue antes de ir" phrasing.
+- Emergency-order popup (community-sourced medical guidance): _"1) Ligar SAMU/bombeiros. 2) Ligar CIATox. 3) Só depois ir ao local com soro."_ — this is medically more correct than the generic "ligue antes de ir" phrasing.
 - CIATox (Centros de Informação e Assistência Toxicológica) integration / reference.
 - Larger soro-type icons on hospital cards (Allan Martinho, Flavia — convergent).
 - "Como chegar" button should use Google Maps icon for instant recognition (Allan).
@@ -75,25 +75,25 @@ Implications for the plan:
 1. Data-correction volume is real and present, not speculative. Per-hospital reports already outnumber open UX complaints. The community-reports layer is justified by current signal, not future guesses.
 2. **Multiple users converging on the same UX issues** (icon size, map radius, search flow) is a strong signal that those specific fixes should ship soon — they're not opinions, they're consensus.
 3. "Data source contributions" is its own category that needs a destination. Enrico's ES sources aren't a "relato da comunidade" on one hospital — they're a pointer to an alternative state-of-truth. Handle this as a separate intake path (see below).
-4. The community-authored emergency-order popup is more correct than the generic disclaimer I earlier proposed. Use *their* wording, not mine.
+4. The community-authored emergency-order popup is more correct than the generic disclaimer I earlier proposed. Use _their_ wording, not mine.
 5. CIATox is the medical-expertise layer for envenomation in Brazil. Adding CIATox state phone numbers to every hospital card may be higher-leverage than any of the above.
 
 ## Report taxonomy
 
 Intake form routes each submission into one of these categories. Each category has a different downstream path.
 
-| # | Category (PT-BR user-facing) | Internal type | Downstream |
-|---|---|---|---|
-| 1 | Telefone, endereço ou horário errado | `data:contact_fix` | Community report → verified override |
-| 2 | Localização no mapa parece errada | `data:pin_fix` | Community report → verified override |
-| 3 | Este hospital/UPA está fechado ou não atende | `data:closed` | Community report (volatile, expires) |
-| 4 | Hospital listado é o errado (unidade trocada) | `data:wrong_unit` | Community report → escalated manual review |
-| 5 | Hospital faltando na lista | `data:missing_hospital` | Community report (new entry) |
-| 6 | Tenho uma fonte oficial melhor (link/PDF) | `data:source_contribution` | Maintainer queue (not public) |
-| 7 | Confirmado que este local atende normalmente | `data:confirmation` | Positive signal aggregator |
-| 8 | Problema no site / sugestão / bug | `product:ux` | GitHub Issues `type:ux` |
-| 9 | Sugestão de nova funcionalidade | `product:feature` | GitHub Issues `type:feature` |
-| 10 | Outro | `other` | Triage queue |
+| #   | Category (PT-BR user-facing)                  | Internal type              | Downstream                                 |
+| --- | --------------------------------------------- | -------------------------- | ------------------------------------------ |
+| 1   | Telefone, endereço ou horário errado          | `data:contact_fix`         | Community report → verified override       |
+| 2   | Localização no mapa parece errada             | `data:pin_fix`             | Community report → verified override       |
+| 3   | Este hospital/UPA está fechado ou não atende  | `data:closed`              | Community report (volatile, expires)       |
+| 4   | Hospital listado é o errado (unidade trocada) | `data:wrong_unit`          | Community report → escalated manual review |
+| 5   | Hospital faltando na lista                    | `data:missing_hospital`    | Community report (new entry)               |
+| 6   | Tenho uma fonte oficial melhor (link/PDF)     | `data:source_contribution` | Maintainer queue (not public)              |
+| 7   | Confirmado que este local atende normalmente  | `data:confirmation`        | Positive signal aggregator                 |
+| 8   | Problema no site / sugestão / bug             | `product:ux`               | GitHub Issues `type:ux`                    |
+| 9   | Sugestão de nova funcionalidade               | `product:feature`          | GitHub Issues `type:feature`               |
+| 10  | Outro                                         | `other`                    | Triage queue                               |
 
 Category 7 (user confirms "this place really does have what the site says") is a useful signal not in today's inbox, but worth collecting to build positive freshness signals, not just negative ones.
 
@@ -116,7 +116,7 @@ Category 6 (**data source contributions**) is special: it's not a per-hospital r
 
 ## Product principle
 
-Use the word **"relato"**, not "comentário" or "correção." *Relato* = useful field signal, not necessarily an official correction. Suggested label: **"Relatos da comunidade."**
+Use the word **"relato"**, not "comentário" or "correção." _Relato_ = useful field signal, not necessarily an official correction. Suggested label: **"Relatos da comunidade."**
 
 Avoid in V1:
 
@@ -165,7 +165,7 @@ Shared fields:
 - Quando você percebeu isso? (Hoje / Últimos 7 dias / Mais antigo / Não sei)
 - Short structured observation (category-specific short text — not a free-text paragraph in V1)
 - Google Maps link for location evidence (optional, for `data:pin_fix` and `data:missing_hospital`)
-- Checkbox: *"Não inclui dados pessoais ou informações de paciente."*
+- Checkbox: _"Não inclui dados pessoais ou informações de paciente."_
 
 Category-specific follow-up fields for missing hospitals (category 5):
 
@@ -196,7 +196,7 @@ Not legal advice. The product intentionally avoids collecting personal data.
 - Do not ask for name, phone, email, or professional role by default.
 - Do not publish raw free text.
 - Do not allow image uploads in V1.
-- Visible note: *"Não envie dados pessoais, informações de paciente, telefone, e-mail ou nomes."*
+- Visible note: _"Não envie dados pessoais, informações de paciente, telefone, e-mail ou nomes."_
 - Store only: structured category, target, report date, optional non-personal location evidence (Maps link), opt-in contact (only if provided and separately consented).
 
 Caveat: backend tooling can create technical logs (IP, user agent). Pick infrastructure and retention with that in mind. GitHub Issues retains submitter metadata for the bot account only; anonymous submissions leave no direct PII trail on the issue body itself, provided the bot posts on behalf of the user.
@@ -208,11 +208,11 @@ References:
 
 ## Freshness and expiration
 
-*Volatile* (change quickly):
+_Volatile_ (change quickly):
 
 - hospital may be closed today; phone didn't answer; staff redirected elsewhere; unit may not have serum right now.
 
-*Stable*:
+_Stable_:
 
 - wrong pin; wrong DDD; wrong address; missing hospital; wrong unit; duplicate/wrong name.
 
@@ -220,8 +220,8 @@ Freshness rules:
 
 - **Stable categories**: keep visible until resolved or superseded.
 - **Hospital closed / may not attend**: prominent for 30 days; downgrade to "relato antigo" after 30; hide from default view after 90 unless repeated.
-- **Phone did not answer**: 14–30 days; phrase *"recomenda-se confirmar por telefone"*, never as proof.
-- **Serum availability**: avoid "sem soro"; safer wording *"relato recente recomenda confirmar disponibilidade antes de se deslocar."*
+- **Phone did not answer**: 14–30 days; phrase _"recomenda-se confirmar por telefone"_, never as proof.
+- **Serum availability**: avoid "sem soro"; safer wording _"relato recente recomenda confirmar disponibilidade antes de se deslocar."_
 - **Positive confirmations**: surface the latest confirmation date per hospital; decays at 90 days.
 
 ## Architecture (GitHub-native, depersonalized)
@@ -231,7 +231,7 @@ Keep the app static-first. Route intake and triage through the project-owned `so
 **Public-site files:**
 
 - `app/hospitals.json` — official + verified data. Current production contract, unchanged.
-- `app/community_reports.json` — sanitized, public, anonymous report summaries (Pipeline A output). Loaded client-side *after* `hospitals.json`. If it fails to load, the app still works as today.
+- `app/community_reports.json` — sanitized, public, anonymous report summaries (Pipeline A output). Loaded client-side _after_ `hospitals.json`. If it fails to load, the app still works as today.
 
 **Intake pipeline:**
 
@@ -250,8 +250,8 @@ Keep the app static-first. Route intake and triage through the project-owned `so
 
 Two paths, choose one:
 
-- *Path A — auto-generated*: a GitHub Action reads closed/labeled Issues, emits sanitized `community_reports.json`, commits, Vercel redeploys. Low-touch.
-- *Path B — manual curation*: the maintainer edits `community_reports.json` during weekly review, same pattern as `location_overrides.json`. Higher trust gate, slower.
+- _Path A — auto-generated_: a GitHub Action reads closed/labeled Issues, emits sanitized `community_reports.json`, commits, Vercel redeploys. Low-touch.
+- _Path B — manual curation_: the maintainer edits `community_reports.json` during weekly review, same pattern as `location_overrides.json`. Higher trust gate, slower.
 
 Start with Path B; upgrade to Path A once there are >~20 active reports and stable category wording.
 
@@ -303,6 +303,7 @@ The public site consumes only the sanitized JSON, never the raw intake store.
 - Community-sourced emergency-order popup/callout on every hospital card, using the medically-vetted wording:
 
   > **Antes de ir ao hospital:**
+  >
   > 1. Ligue para o SAMU (192) ou Bombeiros (193)
   > 2. Ligue para o CIATox do seu estado
   > 3. Só depois dirija-se a um local com soro
@@ -317,7 +318,7 @@ Each of these fixes comes directly from community input and should ship regardle
 
 - Small "Reportar erro" action.
 - If reports exist, a compact "Relatos da comunidade" row below the address/source area. Details collapsed by default.
-- Latest positive confirmation (if any): *"Última confirmação da comunidade: 20/04/2026."*
+- Latest positive confirmation (if any): _"Última confirmação da comunidade: 20/04/2026."_
 
 **On empty or weak search results:**
 

--- a/outreach/pesa_list_gaps.md
+++ b/outreach/pesa_list_gaps.md
@@ -1,14 +1,17 @@
-
 ## 2026-05-13 — Conceição do Mato Dentro/MG
+
 **Source:** Secretaria Municipal de Saúde de Conceição do Mato Dentro (saude@cmd.mg.gov.br)
 **Issue:** UPA Dr. Juvêncio Guimarães handles all antivenom in the município (Antibotrópico, Anticrotálico, Antiescorpiônico) but is **not on the federal PESA list**. The Ministry PDF only has Hospital Imaculada Conceição (CNES 2134071, Escorpiônico only) for the city.
 **Ask:** include UPA Dr. Juvêncio Guimarães in PESA; verify Hospital Imaculada Conceição's status.
 **Status:** community note posted on CNES 2134071 attributing the Secretaria; awaiting Ministry/Abracit follow-up.
 
 ## 2026-05-13 — Pernambuco coverage
+
 **Source:** community report via UPA Coruripe form (CNES 7471645, wrong attachment).
 **Issue:** Reporter says PE has no antivenom hospitals on the site. Verified 4 of 6 named are present (Restauração/Recife, Mestre Vitalino/Caruaru, Dom Moura/Garanhuns, Belarmino Correia/Goiana). Two are missing from our data because they're **not on the Ministry PESA list for PE**:
+
 - Hospital Otávio de Freitas (Recife)
 - Hospital Metropolitano Oeste Pelopidas Silveira (Recife/Jaboatão)
+
 **Ask:** request Ministry/Abracit review of PE's PESA list — confirm whether these two hospitals carry antivenom and should be added.
 **Status:** no app-side change. Reply sent to reporter explaining.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,29 @@
+{
+  "name": "sos-antiveneno",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "sos-antiveneno",
+      "devDependencies": {
+        "prettier": "3.6.2"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
+      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "sos-antiveneno",
+  "private": true,
+  "scripts": {
+    "format": "prettier --write \"**/*.{json,md,yml,yaml}\"",
+    "format:check": "prettier --check \"**/*.{json,md,yml,yaml}\""
+  },
+  "devDependencies": {
+    "prettier": "3.6.2"
+  }
+}

--- a/scripts/tests/test_security_config.py
+++ b/scripts/tests/test_security_config.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+VERCEL_CONFIG = ROOT / "vercel.json"
+
+
+def load_headers() -> dict[str, str]:
+    config = json.loads(VERCEL_CONFIG.read_text(encoding="utf-8"))
+    header_sets = config["headers"]
+    assert len(header_sets) == 1
+    assert header_sets[0]["source"] == "/(.*)"
+    return {item["key"]: item["value"] for item in header_sets[0]["headers"]}
+
+
+def parse_csp(value: str) -> dict[str, list[str]]:
+    directives: dict[str, list[str]] = {}
+    for raw_directive in value.split(";"):
+        raw_directive = raw_directive.strip()
+        if not raw_directive:
+            continue
+        name, *tokens = raw_directive.split()
+        directives[name] = tokens
+    return directives
+
+
+def test_security_headers_are_present_and_restrictive():
+    headers = load_headers()
+
+    assert headers["X-Content-Type-Options"] == "nosniff"
+    assert headers["X-Frame-Options"] == "DENY"
+    assert headers["Referrer-Policy"] == "strict-origin-when-cross-origin"
+    assert headers["Strict-Transport-Security"] == (
+        "max-age=63072000; includeSubDomains; preload"
+    )
+    assert headers["Permissions-Policy"] == (
+        "geolocation=(self), camera=(), microphone=(), payment=()"
+    )
+
+
+def test_content_security_policy_keeps_static_app_boundaries():
+    directives = parse_csp(load_headers()["Content-Security-Policy"])
+
+    assert directives["default-src"] == ["'self'"]
+    assert directives["frame-ancestors"] == ["'none'"]
+    assert directives["base-uri"] == ["'self'"]
+    assert directives["form-action"] == ["'self'"]
+
+
+def test_content_security_policy_does_not_allow_wildcard_sources():
+    directives = parse_csp(load_headers()["Content-Security-Policy"])
+
+    for directive_name in ("connect-src", "script-src", "img-src"):
+        assert all("*" not in source for source in directives[directive_name])
+        assert "https:" not in directives[directive_name]
+
+
+def test_inline_script_and_style_allowances_are_explicit_exceptions():
+    directives = parse_csp(load_headers()["Content-Security-Policy"])
+
+    # The app currently ships inline HTML, CSS, and JavaScript. Keep this
+    # exception visible until the static shell is refactored to nonce or hash
+    # based CSP.
+    assert "'unsafe-inline'" in directives["style-src"]
+    assert "'unsafe-inline'" in directives["script-src"]

--- a/vercel.json
+++ b/vercel.json
@@ -1,20 +1,28 @@
 {
   "outputDirectory": "app",
   "cleanUrls": true,
-  "rewrites": [
-    { "source": "/(.*)", "destination": "/$1" }
-  ],
+  "rewrites": [{ "source": "/(.*)", "destination": "/$1" }],
   "headers": [
     {
       "source": "/(.*)",
       "headers": [
         { "key": "X-Content-Type-Options", "value": "nosniff" },
         { "key": "X-Frame-Options", "value": "DENY" },
-        { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
-        { "key": "Permissions-Policy", "value": "geolocation=(self), camera=(), microphone=(), payment=()" },
+        {
+          "key": "Strict-Transport-Security",
+          "value": "max-age=63072000; includeSubDomains; preload"
+        },
+        {
+          "key": "Referrer-Policy",
+          "value": "strict-origin-when-cross-origin"
+        },
+        {
+          "key": "Permissions-Policy",
+          "value": "geolocation=(self), camera=(), microphone=(), payment=()"
+        },
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; style-src 'self' 'unsafe-inline' https://unpkg.com https://fonts.googleapis.com; script-src 'self' 'unsafe-inline' https://unpkg.com; img-src 'self' data: https://*.tile.openstreetmap.org https://unpkg.com; connect-src 'self' https://unpkg.com https://fonts.googleapis.com https://fonts.gstatic.com; font-src 'self' data: https://fonts.gstatic.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
+          "value": "default-src 'self'; style-src 'self' 'unsafe-inline' https://unpkg.com https://fonts.googleapis.com; script-src 'self' 'unsafe-inline' https://unpkg.com; img-src 'self' data: https://a.tile.openstreetmap.org https://b.tile.openstreetmap.org https://c.tile.openstreetmap.org https://unpkg.com; connect-src 'self' https://unpkg.com https://fonts.googleapis.com https://fonts.gstatic.com; font-src 'self' data: https://fonts.gstatic.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
         }
       ]
     }


### PR DESCRIPTION
## Summary
- split the single CI `tests` job into focused checks for canonicalizer, unit tests, dataset validation, Prettier, and security config
- add npm/Prettier tooling with a lockfile plus Dependabot monitoring for npm and GitHub Actions
- add repo-specific security configuration tests and tighten the Vercel CSP/header config
- update GitHub Actions Python runtime to 3.13 and use Node 24 for formatting

## Validation
- `npm ci`
- `npm run format:check`
- `python3 scripts/canonicalize_antivenoms.py --self-test`
- `/Users/xndvaz/dev/sos-antiveneno/.venv/bin/python -m pytest scripts/tests/ -v --ignore=scripts/tests/test_security_config.py`
- `/Users/xndvaz/dev/sos-antiveneno/.venv/bin/python -m pytest scripts/tests/test_security_config.py -v`
- `python3 scripts/validate_hospitals_json.py app/hospitals.json`
- pre-commit reviewer gate passed on the final staged diff
- `git log --show-signature -1` verified the commit signature
