### PR TITLE
docs(process): document external refresh handoff

### DIFF
--- a/docs/PROCESS.md
+++ b/docs/PROCESS.md
@@ -5,6 +5,50 @@ source PDFs to the file served by the live app. One pass, ~15 minutes of
 click-and-verify work plus Google geocoding time (roughly 8 minutes for a
 full 2,271-row cold run; seconds on a warm resume).
 
+## External contributor path
+
+External contributors do not need access to the private Google Maps
+geocoding key to open a useful data-refresh PR. The maintainer-owned secret
+stays private; contributors can stop at the candidate extraction and diff
+review handoff.
+
+Contributor-owned steps:
+
+1. Run `python3 scripts/check_updates.py` or use the automated
+   `data-refresh` issue to identify the stale UF.
+2. Download the updated Ministry of Health PDF into `Docs Estado/` using the
+   `{UF}_{YYYYMMDD}.pdf` naming convention.
+3. Re-extract only the affected state to `extracted/{UF}.new.json`. Do not
+   overwrite `extracted/{UF}.json` in a contributor PR.
+4. Run the candidate diff:
+
+   ```bash
+   python3 scripts/refresh_diff.py --uf BA \
+       --candidate extracted/BA.new.json --write
+   ```
+
+5. Open a PR with the candidate extraction, the generated
+   `reports/refresh_diff_{UF}_*.md` report, and the source-date/hash metadata
+   when it can be verified from the downloaded PDF.
+
+Use a non-closing reference such as `Refs #17` or `Refs #<data-refresh-issue>`
+for this kind of partial handoff. Do not use `Fixes` or `Closes` unless the
+PR also completes maintainer geocoding, promotion, artifact rebuild, and
+validation.
+
+Maintainer-owned follow-up:
+
+1. Review every added, removed, changed, and override-audited CNES in the
+   refresh diff.
+2. Promote the candidate to `extracted/{UF}.json` only after review.
+3. Update `data/source_dates.json` and `data/source_hashes.json`.
+4. Run the full refresh with `GOOGLE_MAPS_API_KEY` or the maintainer's
+   Keychain entry.
+5. Validate and publish the regenerated app artifacts.
+
+This split keeps the Google Maps key out of forks and untrusted PR execution
+while still letting contributors prepare reviewable refresh work.
+
 ## TL;DR
 
 ```bash


### PR DESCRIPTION
## Summary
- Document the external-contributor data refresh path in `docs/PROCESS.md`.
- Split the refresh workflow into contributor-owned candidate extraction/diff steps and maintainer-owned geocoding/promotion steps.
- Clarify that Google Maps geocoding secrets remain private and partial refresh PRs should use non-closing issue references.

## Context
Issue #17 identifies that external contributors can re-extract updated PESA PDFs and review diffs, but cannot run the full refresh locally without the private Google Maps geocoding key. The narrow fix is to document the useful partial PR path that already exists around `extracted/{UF}.new.json` and `scripts/refresh_diff.py`, while leaving final geocoding and artifact publication with the maintainer.

## Scope
This intentionally does not change:
- `scripts/refresh_dataset.sh`
- Google Maps key handling
- GitHub Actions or maintainer secrets
- geocoding, promotion, or rebuild semantics
- generated hospital data, reports, or build artifacts

Refs #17

## Testing
- `git diff --check -- docs/PROCESS.md`
- `bash /Users/xndvaz/.dotfiles/scripts/hooks/pre-commit` on the staged docs diff
- `git log --show-signature -1`

## AI assistance
This PR was prepared with AI assistance. I personally reviewed the final diff, scope, and validation, and I take responsibility for the changes.