### PR TITLE
data: RJ refresh from 2026-07-03 MS PDF (extraction validated, geocoding blocked)

### DIFF
--- a/app/hospitals.json
+++ b/app/hospitals.json
@@ -47225,7 +47225,7 @@
     "state_name": "Rio de Janeiro",
     "city": "Armação dos Búzios",
     "hospital_name": "Hospital Municipal Dr. Rodolpho Perissé",
-    "address": "Avenida 12 de novembro (São José)",
+    "address": "Avenida 12 de novembro - São José",
     "phones": [
       "(22) 2623-6051",
       "(22) 2623-7622"
@@ -47389,37 +47389,6 @@
     "lat": -21.6656424,
     "lng": -42.0780019,
     "geocode_tier": 1
-  },
-  {
-    "state": "RJ",
-    "state_name": "Rio de Janeiro",
-    "city": "Itaperuna",
-    "hospital_name": "UPA Itaperuna",
-    "address": "RUA E, 1 Cidade Nova",
-    "phones": [
-      "(22) 3822-4657"
-    ],
-    "cnes": "6855334",
-    "antivenoms": [
-      "Fonêutrico",
-      "Loxoscélico",
-      "Botrópico",
-      "Crotálico",
-      "Elapídico",
-      "Escorpiônico"
-    ],
-    "source_antivenoms_raw": [
-      "Fonêutrico",
-      "Loxoscélico",
-      "Botrópico",
-      "Crotálico",
-      "Elapídico",
-      "Escorpiônico"
-    ],
-    "source_date": "2026-01-05",
-    "lat": -21.1997534,
-    "lng": -41.9122044,
-    "geocode_tier": 3
   },
   {
     "state": "RJ",
@@ -47665,7 +47634,7 @@
     "state_name": "Rio de Janeiro",
     "city": "Petrópolis",
     "hospital_name": "UPA Cascatinha",
-    "address": "R. Bernardo Proença, 500 - Itamarati",
+    "address": "R. Bernardo Proença, 500 - Cascatinha",
     "phones": [
       "(24) 2246-8931",
       "(24) 2280-0702",
@@ -47982,6 +47951,149 @@
     "source_date": "2026-01-05",
     "lat": -22.508902136615422,
     "lng": -44.09011867877822,
+    "geocode_tier": 1
+  },
+  {
+    "state": "RJ",
+    "state_name": "Rio de Janeiro",
+    "city": "Paraíba do Sul",
+    "hospital_name": "Hospital Nossa Senhora da Piedade",
+    "address": "Av. Provedor Randolpho Penna Júnior, 320 - Vila Nicolau Melick",
+    "phones": [
+      "(24) 98167-0027"
+    ],
+    "cnes": "2276186",
+    "antivenoms": [
+      "Fonêutrico",
+      "Loxoscélico",
+      "Botrópico",
+      "Crotálico",
+      "Elapídico",
+      "Escorpiônico"
+    ],
+    "source_antivenoms_raw": [
+      "Fonêutrico",
+      "Loxoscélico",
+      "Botrópico",
+      "Crotálico",
+      "Elapídico",
+      "Escorpiônico"
+    ],
+    "source_date": "2026-07-03",
+    "lat": -22.1639849,
+    "lng": -43.2942472,
+    "geocode_tier": 1
+  },
+  {
+    "state": "RJ",
+    "state_name": "Rio de Janeiro",
+    "city": "Itaperuna",
+    "hospital_name": "Posto de Urgência de Itaperuna",
+    "address": "Rua Cardoso Moreira, 897",
+    "phones": [
+      "(22) 3822-4657"
+    ],
+    "cnes": "2279274",
+    "antivenoms": [
+      "Fonêutrico",
+      "Loxoscélico",
+      "Botrópico",
+      "Crotálico",
+      "Elapídico",
+      "Escorpiônico"
+    ],
+    "source_antivenoms_raw": [
+      "Fonêutrico",
+      "Loxoscélico",
+      "Botrópico",
+      "Crotálico",
+      "Elapídico",
+      "Escorpiônico"
+    ],
+    "source_date": "2026-07-03",
+    "lat": -21.203276,
+    "lng": -41.892226,
+    "geocode_tier": 1
+  },
+  {
+    "state": "RJ",
+    "state_name": "Rio de Janeiro",
+    "city": "Barra do Piraí",
+    "hospital_name": "Hospital Nova Santa Casa de Barra do Piraí",
+    "address": "Rua Franklin de Moraes, 67, Centro",
+    "phones": [
+      "(24) 2447-2750"
+    ],
+    "cnes": "2287919",
+    "antivenoms": [
+      "Botrópico",
+      "Crotálico",
+      "Escorpiônico"
+    ],
+    "source_antivenoms_raw": [
+      "Botrópico",
+      "Crotálico",
+      "Escorpiônico"
+    ],
+    "source_date": "2026-07-03",
+    "lat": -22.4700253,
+    "lng": -43.8225565,
+    "geocode_tier": 1
+  },
+  {
+    "state": "RJ",
+    "state_name": "Rio de Janeiro",
+    "city": "Barra do Piraí",
+    "hospital_name": "Hospital e Maternidade Maria de Nazaré",
+    "address": "Rua Frutuoso Gil Gonçalves,115, Matadouro",
+    "phones": [
+      "(24) 3512-6100"
+    ],
+    "cnes": "2287927",
+    "antivenoms": [
+      "Botrópico",
+      "Crotálico",
+      "Escorpiônico"
+    ],
+    "source_antivenoms_raw": [
+      "Botrópico",
+      "Crotálico",
+      "Escorpiônico"
+    ],
+    "source_date": "2026-07-03",
+    "lat": -22.4613711,
+    "lng": -43.8260489,
+    "geocode_tier": 1
+  },
+  {
+    "state": "RJ",
+    "state_name": "Rio de Janeiro",
+    "city": "Petrópolis",
+    "hospital_name": "UPH Pedro do Rio",
+    "address": "Estr. União Indústria, 19691",
+    "phones": [
+      "(24) 2223-2035"
+    ],
+    "cnes": "4751140",
+    "antivenoms": [
+      "Fonêutrico",
+      "Loxoscélico",
+      "Botrópico",
+      "Crotálico",
+      "Elapídico",
+      "Escorpiônico"
+    ],
+    "source_antivenoms_raw": [
+      "Fonêutrico",
+      "Loxoscélico",
+      "Botrópico",
+      "Crotálico",
+      "Elapídico",
+      "Escorpiônico"
+    ],
+    "source_date": "2026-07-03",
+    "lat": -22.3318535,
+    "lng": -43.1315447,
     "geocode_tier": 1
   },
   {

--- a/hospitals.json
+++ b/hospitals.json
@@ -47225,7 +47225,7 @@
     "state_name": "Rio de Janeiro",
     "city": "Armação dos Búzios",
     "hospital_name": "Hospital Municipal Dr. Rodolpho Perissé",
-    "address": "Avenida 12 de novembro (São José)",
+    "address": "Avenida 12 de novembro - São José",
     "phones": [
       "(22) 2623-6051",
       "(22) 2623-7622"
@@ -47389,37 +47389,6 @@
     "lat": -21.6656424,
     "lng": -42.0780019,
     "geocode_tier": 1
-  },
-  {
-    "state": "RJ",
-    "state_name": "Rio de Janeiro",
-    "city": "Itaperuna",
-    "hospital_name": "UPA Itaperuna",
-    "address": "RUA E, 1 Cidade Nova",
-    "phones": [
-      "(22) 3822-4657"
-    ],
-    "cnes": "6855334",
-    "antivenoms": [
-      "Fonêutrico",
-      "Loxoscélico",
-      "Botrópico",
-      "Crotálico",
-      "Elapídico",
-      "Escorpiônico"
-    ],
-    "source_antivenoms_raw": [
-      "Fonêutrico",
-      "Loxoscélico",
-      "Botrópico",
-      "Crotálico",
-      "Elapídico",
-      "Escorpiônico"
-    ],
-    "source_date": "2026-01-05",
-    "lat": -21.1997534,
-    "lng": -41.9122044,
-    "geocode_tier": 3
   },
   {
     "state": "RJ",
@@ -47665,7 +47634,7 @@
     "state_name": "Rio de Janeiro",
     "city": "Petrópolis",
     "hospital_name": "UPA Cascatinha",
-    "address": "R. Bernardo Proença, 500 - Itamarati",
+    "address": "R. Bernardo Proença, 500 - Cascatinha",
     "phones": [
       "(24) 2246-8931",
       "(24) 2280-0702",
@@ -47982,6 +47951,149 @@
     "source_date": "2026-01-05",
     "lat": -22.508902136615422,
     "lng": -44.09011867877822,
+    "geocode_tier": 1
+  },
+  {
+    "state": "RJ",
+    "state_name": "Rio de Janeiro",
+    "city": "Paraíba do Sul",
+    "hospital_name": "Hospital Nossa Senhora da Piedade",
+    "address": "Av. Provedor Randolpho Penna Júnior, 320 - Vila Nicolau Melick",
+    "phones": [
+      "(24) 98167-0027"
+    ],
+    "cnes": "2276186",
+    "antivenoms": [
+      "Fonêutrico",
+      "Loxoscélico",
+      "Botrópico",
+      "Crotálico",
+      "Elapídico",
+      "Escorpiônico"
+    ],
+    "source_antivenoms_raw": [
+      "Fonêutrico",
+      "Loxoscélico",
+      "Botrópico",
+      "Crotálico",
+      "Elapídico",
+      "Escorpiônico"
+    ],
+    "source_date": "2026-07-03",
+    "lat": -22.1639849,
+    "lng": -43.2942472,
+    "geocode_tier": 1
+  },
+  {
+    "state": "RJ",
+    "state_name": "Rio de Janeiro",
+    "city": "Itaperuna",
+    "hospital_name": "Posto de Urgência de Itaperuna",
+    "address": "Rua Cardoso Moreira, 897",
+    "phones": [
+      "(22) 3822-4657"
+    ],
+    "cnes": "2279274",
+    "antivenoms": [
+      "Fonêutrico",
+      "Loxoscélico",
+      "Botrópico",
+      "Crotálico",
+      "Elapídico",
+      "Escorpiônico"
+    ],
+    "source_antivenoms_raw": [
+      "Fonêutrico",
+      "Loxoscélico",
+      "Botrópico",
+      "Crotálico",
+      "Elapídico",
+      "Escorpiônico"
+    ],
+    "source_date": "2026-07-03",
+    "lat": -21.203276,
+    "lng": -41.892226,
+    "geocode_tier": 1
+  },
+  {
+    "state": "RJ",
+    "state_name": "Rio de Janeiro",
+    "city": "Barra do Piraí",
+    "hospital_name": "Hospital Nova Santa Casa de Barra do Piraí",
+    "address": "Rua Franklin de Moraes, 67, Centro",
+    "phones": [
+      "(24) 2447-2750"
+    ],
+    "cnes": "2287919",
+    "antivenoms": [
+      "Botrópico",
+      "Crotálico",
+      "Escorpiônico"
+    ],
+    "source_antivenoms_raw": [
+      "Botrópico",
+      "Crotálico",
+      "Escorpiônico"
+    ],
+    "source_date": "2026-07-03",
+    "lat": -22.4700253,
+    "lng": -43.8225565,
+    "geocode_tier": 1
+  },
+  {
+    "state": "RJ",
+    "state_name": "Rio de Janeiro",
+    "city": "Barra do Piraí",
+    "hospital_name": "Hospital e Maternidade Maria de Nazaré",
+    "address": "Rua Frutuoso Gil Gonçalves,115, Matadouro",
+    "phones": [
+      "(24) 3512-6100"
+    ],
+    "cnes": "2287927",
+    "antivenoms": [
+      "Botrópico",
+      "Crotálico",
+      "Escorpiônico"
+    ],
+    "source_antivenoms_raw": [
+      "Botrópico",
+      "Crotálico",
+      "Escorpiônico"
+    ],
+    "source_date": "2026-07-03",
+    "lat": -22.4613711,
+    "lng": -43.8260489,
+    "geocode_tier": 1
+  },
+  {
+    "state": "RJ",
+    "state_name": "Rio de Janeiro",
+    "city": "Petrópolis",
+    "hospital_name": "UPH Pedro do Rio",
+    "address": "Estr. União Indústria, 19691",
+    "phones": [
+      "(24) 2223-2035"
+    ],
+    "cnes": "4751140",
+    "antivenoms": [
+      "Fonêutrico",
+      "Loxoscélico",
+      "Botrópico",
+      "Crotálico",
+      "Elapídico",
+      "Escorpiônico"
+    ],
+    "source_antivenoms_raw": [
+      "Fonêutrico",
+      "Loxoscélico",
+      "Botrópico",
+      "Crotálico",
+      "Elapídico",
+      "Escorpiônico"
+    ],
+    "source_date": "2026-07-03",
+    "lat": -22.3318535,
+    "lng": -43.1315447,
     "geocode_tier": 1
   },
   {

--- a/reports/pesa_20260703_25uf_claude_validation_2026-07-26.md
+++ b/reports/pesa_20260703_25uf_claude_validation_2026-07-26.md
@@ -77,6 +77,18 @@ Independent of Codex's tmp extractors. For each of the 25 candidate UFs:
 - `reports/refresh_diff_RJ_2026-07-26.md` — regenerated from the corrected candidate, matches this report.
 - `app/hospitals.json`, `hospitals.json`, `build/*` — untouched, identical to `main`.
 
-**Next step once Eduardo restores geocoding access:** re-run `scripts/geocode_hospitals.py` (it will resume from cache and only need to fetch the 5 new addresses plus the 3 rows whose cache got busted), then `./scripts/refresh_dataset.sh` end-to-end, verify the published count is exactly 2,272 + 4 = 2,276 with zero drops elsewhere, then this branch is ready for Eduardo's production go/no-go.
+**Resolved without API geocoding.** Eduardo confirmed the 5 addresses were correct and asked to skip the API and provide coordinates manually. Looked each of the 5 up individually on Google Maps (address text cross-checked against the PESA PDF for every one), captured verified lat/lng, and hand-patched `app/hospitals.json` + `hospitals.json` directly — bypassing the broken Google Geocoding API entirely rather than waiting on the billing fix:
+
+| CNES | Unidade | Coordinates |
+|---|---|---|
+| 2276186 | Hospital Nossa Senhora da Piedade | -22.1639849, -43.2942472 |
+| 2279274 | Posto de Urgência de Itaperuna | -21.203276, -41.892226 |
+| 2287919 | Hospital Nova Santa Casa de Barra do Piraí | -22.4700253, -43.8225565 |
+| 2287927 | Hospital e Maternidade Maria de Nazaré | -22.4613711, -43.8260489 |
+| 4751140 | UPH Pedro do Rio | -22.3318535, -43.1315447 |
+
+Built the 5 new records with `scripts/phone_utils.expand_phones` and `scripts/canonicalize_antivenoms.canonicalize_list` (the same library functions `build_app_hospitals_json.py` uses) so the schema matches exactly — not a hand-typed shortcut. `geocode_tier: 1` (manually verified, equivalent to ROOFTOP). Removed CNES 6855334, applied the 2 address corrections. Confirmed via `scripts/validate_hospitals_json.py` (2,276 records, OK) and a CNES-level diff against `main`: **added {2276186, 2279274, 2287919, 2287927, 4751140}, removed {6855334}, changed {6200702, 6922597} — nothing else touched.** Verified live in a local preview (`python3 -m http.server` on `app/`): searched "Itaperuna", the new Posto de Urgência de Itaperuna card renders correctly with the right address, phone, antivenom icons, and "Atualizado 03/07/2026 — Fonte: MS".
+
+The Google Cloud billing blocker documented above is still real and still blocks the *automated* pipeline (`scripts/geocode_hospitals.py` / `refresh_dataset.sh`) for any future full refresh — but is no longer blocking this specific RJ change, which is now complete and ready for Eduardo's go/no-go on PR #37.
 
 **Remaining 24 UFs: not attempted this session.** Given the RJ case just demonstrated that automated table extraction can silently drop rows even in a small, clean 3-page PDF, and that a blind full-text strict-match field check produces too many false positives on larger/messier states (line-wrap reading-order issues), promoting any of the other 24 states' data safely requires the same hand-verification approach used for RJ here — realistically hours of dedicated work per larger state (MG 295 rows, PR 204, PA 172, AM 95). Not attempted in this pass to avoid rushing state-by-state verification for a safety-critical dataset. The `refresh_diff_{UF}_2026-07-26.md` reports for all 25 states are committed for reference; none of the other 24 `extracted/{UF}.json` files were modified.


### PR DESCRIPTION
## Summary
- Refs #36 (weekly MS-update checker)
- Hand-verified re-extraction of `extracted/RJ.json` against the Ministério da Saúde's new 2026-07-03 PDF: **29 → 33 rows** (5 added, 1 removed, 2 minor address corrections). Validated with `scripts/refresh_diff.py --uf RJ` — see `reports/refresh_diff_RJ_2026-07-26.md`.
- Along the way, caught pdfplumber's table detector silently dropping 2 rows from the raw PDF (one genuine addition, one pre-existing hospital) — full details in `reports/pesa_20260703_25uf_claude_validation_2026-07-26.md`.
- `data/source_dates.json` / `data/source_hashes.json` bumped for RJ only.
- **`app/hospitals.json` / `hospitals.json` updated: 2,272 → 2,276 records.** The 5 new hospitals' coordinates were geocoded manually (Google Maps, address cross-checked against the PDF for each) after the automated Google Geocoding API turned out to be billing-disabled on the dev machine — see blocker note below. Built with the same phone/antivenom canonicalization helpers `build_app_hospitals_json.py` uses, so the schema matches exactly.
- Adds the 2026-07-03 25-UF PESA review artifacts (per-state `refresh_diff_*.md`, add/remove validation) for the other 24 states MS republished — **no other state's `extracted/{UF}.json` or published data was touched**; those remain gated behind manual per-state re-extraction.

## Verified diff (CNES-level, against `main`)
- **Added:** 2276186 (Hospital Nossa Senhora da Piedade), 2279274 (Posto de Urgência de Itaperuna), 2287919 (Hospital Nova Santa Casa de Barra do Piraí), 2287927 (Hospital e Maternidade Maria de Nazaré), 4751140 (UPH Pedro do Rio)
- **Removed:** 6855334 (UPA Itaperuna — replaced by 2279274, same phone, new address)
- **Changed:** 6200702 (cosmetic dash formatting), 6922597 (neighborhood corrected: Itamarati → Cascatinha, per new PDF)
- Nothing else in the 2,276-record dataset moved.

## Known blocker (unrelated to this PR's data, but worth flagging)
The Google Maps Geocoding API key on this dev machine is billing-disabled (`REQUEST_DENIED`). This blocks the *automated* refresh pipeline (`scripts/geocode_hospitals.py` / `refresh_dataset.sh`) for any future state refresh until Eduardo re-enables billing or rotates the key — worked around for this PR via manual coordinates since only 5 addresses needed geocoding. An earlier attempt to run the full pipeline under the degraded key surfaced a real risk (34 hospitals across 9 unrelated states got silently dropped by failing repair-script retries) — caught before anything was committed, not part of this PR.

## Test plan
- [x] `scripts/refresh_diff.py --uf RJ` run against the hand-verified candidate — report attached
- [x] `scripts/validate_hospitals_json.py app/hospitals.json` — OK, 2,276 records
- [x] CNES-level diff against `main` confirms only the 7 RJ CNES above changed
- [x] Local preview (`python3 -m http.server` on `app/`) — searched "Itaperuna", confirmed the new card renders with correct address/phone/antivenoms/source date
- [ ] Eduardo's explicit go/no-go before merge + deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)