### PR TITLE
Make community reports unmistakable before hospital actions

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -80,6 +80,14 @@
             --legal-modal-border: var(--danger);
             --link-color: #0066CC;
             --footer-text: #6B7280;
+            --community-critical-bg: #FFF1F2;
+            --community-critical-border: #E11D48;
+            --community-critical-title: #9F1239;
+            --community-critical-text: #881337;
+            --community-advisory-bg: #FFFBEB;
+            --community-advisory-border: #D97706;
+            --community-advisory-title: #92400E;
+            --community-advisory-text: #78350F;
         }
 
         [data-theme="dark"] {
@@ -119,6 +127,14 @@
             --legal-modal-border: var(--danger);
             --link-color: #93C5FD;
             --footer-text: #888;
+            --community-critical-bg: #4C0519;
+            --community-critical-border: #FB7185;
+            --community-critical-title: #FDA4AF;
+            --community-critical-text: #FFE4E6;
+            --community-advisory-bg: #422006;
+            --community-advisory-border: #F59E0B;
+            --community-advisory-title: #FCD34D;
+            --community-advisory-text: #FEF3C7;
         }
 
         * { box-sizing: border-box; margin: 0; padding: 0; font-family: 'Outfit', sans-serif; -webkit-tap-highlight-color: transparent; }
@@ -357,30 +373,52 @@
             border-radius: 8px; font-size: 12px; color: #FCD34D; line-height: 1.45;
             white-space: pre-line;
         }
-        /* Community-reported relatos. Visually distinct from .hospital-note
-           (which is maintainer-verified) — dashed border, dimmer amber, and
-           a date prefix make the trust contract explicit. Always visible. */
-        .card .community-relatos {
-            margin-top: 6px; padding: 10px 12px; background: rgba(245,158,11,0.06);
-            border: 1px dashed rgba(245,158,11,0.45); border-radius: 8px;
-            font-size: 12px; line-height: 1.45;
+        /* Community reports are a separate trust layer. Critical service or
+           location warnings must interrupt the path to directions/actions. */
+        .community-alert {
+            margin-top: 16px; padding: 16px; border: 2px solid;
+            border-radius: 16px; font-size: 14px; line-height: 1.5;
         }
-        .card .relato-label {
-            display: block; color: #FCD34D; font-weight: 800; font-size: 11px;
-            text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 8px;
+        .community-alert-critical {
+            background: var(--community-critical-bg);
+            border-color: var(--community-critical-border);
+            color: var(--community-critical-text);
         }
-        .card .community-relato {
-            color: #FCD34D; margin-bottom: 6px; display: flex; gap: 6px;
+        .community-alert-advisory {
+            background: var(--community-advisory-bg);
+            border-color: var(--community-advisory-border);
+            color: var(--community-advisory-text);
         }
-        .card .community-relato:last-of-type { margin-bottom: 0; }
-        .card .community-relato .relato-date {
-            font-weight: 800; flex-shrink: 0; opacity: 0.85;
+        .community-alert-header { display: flex; align-items: center; gap: 10px; margin-bottom: 10px; }
+        .community-alert-icon {
+            width: 32px; height: 32px; border-radius: 50%; flex: 0 0 32px;
+            display: inline-flex; align-items: center; justify-content: center;
+            color: white; background: var(--community-critical-border);
+            font-size: 20px; font-weight: 900;
         }
-        .card .community-relato .relato-text { flex: 1; }
-        .card .relato-disclaimer {
-            margin-top: 8px; padding-top: 8px;
-            border-top: 1px solid rgba(245,158,11,0.2);
-            font-size: 11px; color: var(--text-muted); font-style: italic;
+        .community-alert-advisory .community-alert-icon { background: var(--community-advisory-border); }
+        .community-alert-eyebrow {
+            display: block; font-size: 11px; font-weight: 900;
+            text-transform: uppercase; letter-spacing: 0.7px;
+        }
+        .community-alert-critical .community-alert-eyebrow,
+        .community-alert-critical .community-alert-title { color: var(--community-critical-title); }
+        .community-alert-advisory .community-alert-eyebrow,
+        .community-alert-advisory .community-alert-title { color: var(--community-advisory-title); }
+        .community-alert-title { margin: 0; font-size: 16px; line-height: 1.25; }
+        .community-relato { margin-bottom: 8px; }
+        .community-relato:last-of-type { margin-bottom: 0; }
+        .community-relato .relato-date {
+            display: block; margin-bottom: 3px; font-size: 12px; font-weight: 800;
+        }
+        .community-alert-guidance {
+            margin-top: 12px; padding-top: 12px; border-top: 1px solid currentColor;
+            font-size: 13px;
+        }
+        .community-alert-source { display: block; margin-top: 5px; font-size: 11px; opacity: 0.85; }
+        .community-alert-report {
+            display: inline-block; margin-top: 10px; color: inherit;
+            font-size: 12px; font-weight: 800; text-underline-offset: 3px;
         }
         .nearest-badge {
             display: inline-block; background: var(--success); color: white; font-size: 12px; font-weight: 900;
@@ -1214,11 +1252,33 @@
     // ===== Build the "Relatos da comunidade" block for a hospital card.
     // Always visible. Returns '' if no notes. All dynamic values are escaped
     // per the existing XSS discipline (see escapeHtml). =====
-    function renderCommunityRelatos(notes) {
+    function communityAlertMeta(notes) {
+        var categories = notes.map(function(n) { return n.category; });
+        if (categories.indexOf('closed') !== -1) {
+            return { severity: 'critical', title: 'Funcionamento questionado' };
+        }
+        if (categories.indexOf('wrong_unit') !== -1) {
+            return { severity: 'critical', title: 'Unidade questionada' };
+        }
+        if (categories.indexOf('pin_fix') !== -1) {
+            return { severity: 'critical', title: 'Localiza\u00e7\u00e3o questionada' };
+        }
+        return { severity: 'advisory', title: 'Informa\u00e7\u00e3o da comunidade' };
+    }
+
+    function formatCommunitySummary(summary) {
+        var text = String(summary || '').trim().replace(
+            /^relatos? da comunidade(?: \(\d+ relatos?\))?:\s*/i,
+            ''
+        );
+        return text ? text.charAt(0).toUpperCase() + text.slice(1) : '';
+    }
+
+    function renderCommunityRelatos(notes, reportUrl) {
         if (!notes || !notes.length) return '';
         var items = notes.map(function(n) {
             var date = formatBrDate(n.reported_at);
-            var summary = String(n.public_summary || '').trim();
+            var summary = formatCommunitySummary(n.public_summary);
             if (!summary) return '';
             return '<div class="community-relato">' +
                 (date ? '<span class="relato-date">' + escapeHtml(date) + '</span>' : '') +
@@ -1226,18 +1286,24 @@
             '</div>';
         }).filter(Boolean).join('');
         if (!items) return '';
-        var count = notes.length;
-        var label = '&#128172; Relatos da comunidade (' + count + ')';
-        return '<div class="community-relatos">' +
-            '<span class="relato-label">' + label + '</span>' +
+        var meta = communityAlertMeta(notes);
+        return '<section class="community-alert community-alert-' + meta.severity + '" role="note" aria-label="Alerta da comunidade">' +
+            '<div class="community-alert-header">' +
+                '<span class="community-alert-icon" aria-hidden="true">!</span>' +
+                '<div><span class="community-alert-eyebrow">Alerta da comunidade</span>' +
+                '<h4 class="community-alert-title">' + meta.title + '</h4></div>' +
+            '</div>' +
             items +
-            '<div class="relato-disclaimer">Informa&ccedil;&atilde;o n&atilde;o confirmada pelo Minist&eacute;rio da Sa&uacute;de. Em emerg&ecirc;ncia, ligue 192.</div>' +
-        '</div>';
+            '<p class="community-alert-guidance"><strong>Antes de ir:</strong> ligue para confirmar o atendimento. Em emerg&ecirc;ncia, ligue 192 ou 193.' +
+                '<span class="community-alert-source">Relato da comunidade, n&atilde;o confirmado pelo Minist&eacute;rio da Sa&uacute;de.</span></p>' +
+            '<a class="community-alert-report" href="' + escapeHtml(reportUrl) + '" target="_blank" rel="noopener">A situa&ccedil;&atilde;o mudou? Avise o SoroJ&aacute;</a>' +
+        '</section>';
     }
 
     // ===== RENDER CARD =====
     function renderCard(h, idx) {
         var isNearest = gpsAvailable && idx === 0;
+        var reportUrl = reportFormUrl(h);
         var distHtml = '';
         if (gpsAvailable && h._dist != null && h._dist < 999999) {
             var approx = (h.geocode_tier === 3) ? ' dist-approx' : '';
@@ -1315,7 +1381,6 @@
         );
 
         // Source date + discrete report link — subtle
-        var reportUrl = reportFormUrl(h);
         var reportLinkHtml = '<a class="btn-report" href="' + escapeHtml(reportUrl) + '" target="_blank" rel="noopener"' +
             ' aria-label="Reportar erro sobre ' + escapeHtml(h.hospital_name || '') + '">Reportar erro</a>';
         var sourceHtml;
@@ -1336,9 +1401,9 @@
                 '<div class="city">' + escapeHtml(h.city) + ', ' + escapeHtml(h.state) + '</div>' +
                 (h.address ? '<div class="address">' + escapeHtml(h.address) + '</div>' : '') +
                 (h.note ? '<div class="hospital-note">' + formatHospitalNote(h.note) + '</div>' : '') +
-                renderCommunityRelatos(h.community_notes) +
                 '</div>' + distHtml +
             '</div>' +
+            renderCommunityRelatos(h.community_notes, reportUrl) +
             tagsHtml +
             mapBlockHtml +
             '<div class="actions">' +
@@ -1589,6 +1654,7 @@
                 escapeHtml(h.city) + ', ' + escapeHtml(h.state) + distText + '<br>' +
                 popupEmojis +
                 (h.note ? '<em style="color:#B26A00">' + formatHospitalNote(h.note) + '</em><br>' : '') +
+                renderCommunityRelatos(h.community_notes, reportFormUrl(h)) +
                 (phonesHtml ? phonesHtml + '<br>' : '') +
                 '<a href="https://www.google.com/maps/dir/?api=1&destination=' + h.lat + ',' + h.lng +
                 '" target="_blank"><svg width="18" height="18" viewBox="0 0 24 24" fill="white" style="flex-shrink:0"><path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z"/></svg> Como Chegar</a>';

--- a/app/index.html
+++ b/app/index.html
@@ -1024,10 +1024,8 @@
             .replace(/'/g, '&#39;');
     }
 
-    // Render an override `note` (community report) with the standing
-    // "Confirme antes de se deslocar" call-to-action bolded. The note is
-    // escaped first; the <strong> wrapper is a static literal injected
-    // post-escape, so this stays XSS-safe.
+    // Render a maintainer/official override note. Legacy community-sourced
+    // override notes are routed through the always-visible alert below.
     function formatHospitalNote(note) {
         if (note == null) return '';
         var safe = escapeHtml(note);
@@ -1035,6 +1033,43 @@
             /Confirme antes de se deslocar/g,
             '<strong>Confirme antes de se deslocar</strong>'
         );
+    }
+
+    function isLegacyCommunityNote(note) {
+        return /^(?:relato comunitário|relatos comunitários|comunidade reportou)\b/i.test(String(note || '').trim());
+    }
+
+    function legacyCommunityCategory(note) {
+        var text = norm(note);
+        if (/encerr|desativ|demolid|fechad|sem soro/.test(text)) return 'closed';
+        if (/transferid|endereco|unidade/.test(text)) return 'wrong_unit';
+        if (/pin|localiz/.test(text)) return 'pin_fix';
+        if (/telefone|contato/.test(text)) return 'contact_fix';
+        return 'other';
+    }
+
+    function legacyCommunitySummary(note) {
+        return String(note || '').trim()
+            .replace(/^(?:relato comunitário|relatos comunitários|comunidade reportou)(?:\s*\([^)]*\))?:\s*/i, '')
+            .replace(/\s*Confirme(?: por telefone)? antes de se deslocar\.?\s*$/i, '')
+            .trim();
+    }
+
+    function communityNotesForHospital(h) {
+        var notes = (h.community_notes || []).slice();
+        if (isLegacyCommunityNote(h.note)) {
+            notes.push({
+                category: legacyCommunityCategory(h.note),
+                reported_at: '',
+                public_summary: legacyCommunitySummary(h.note)
+            });
+        }
+        return notes;
+    }
+
+    function renderHospitalNote(note) {
+        if (!note || isLegacyCommunityNote(note)) return '';
+        return '<div class="hospital-note">' + formatHospitalNote(note) + '</div>';
     }
 
     function haversine(lat1, lon1, lat2, lon2) {
@@ -1400,10 +1435,10 @@
                 '<div><h3>' + escapeHtml(h.hospital_name) + '</h3>' +
                 '<div class="city">' + escapeHtml(h.city) + ', ' + escapeHtml(h.state) + '</div>' +
                 (h.address ? '<div class="address">' + escapeHtml(h.address) + '</div>' : '') +
-                (h.note ? '<div class="hospital-note">' + formatHospitalNote(h.note) + '</div>' : '') +
+                renderHospitalNote(h.note) +
                 '</div>' + distHtml +
             '</div>' +
-            renderCommunityRelatos(h.community_notes, reportUrl) +
+            renderCommunityRelatos(communityNotesForHospital(h), reportUrl) +
             tagsHtml +
             mapBlockHtml +
             '<div class="actions">' +
@@ -1653,8 +1688,8 @@
             var popup = '<strong>' + escapeHtml(h.hospital_name) + '</strong><br>' +
                 escapeHtml(h.city) + ', ' + escapeHtml(h.state) + distText + '<br>' +
                 popupEmojis +
-                (h.note ? '<em style="color:#B26A00">' + formatHospitalNote(h.note) + '</em><br>' : '') +
-                renderCommunityRelatos(h.community_notes, reportFormUrl(h)) +
+                (h.note && !isLegacyCommunityNote(h.note) ? '<em style="color:#B26A00">' + formatHospitalNote(h.note) + '</em><br>' : '') +
+                renderCommunityRelatos(communityNotesForHospital(h), reportFormUrl(h)) +
                 (phonesHtml ? phonesHtml + '<br>' : '') +
                 '<a href="https://www.google.com/maps/dir/?api=1&destination=' + h.lat + ',' + h.lng +
                 '" target="_blank"><svg width="18" height="18" viewBox="0 0 24 24" fill="white" style="flex-shrink:0"><path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z"/></svg> Como Chegar</a>';

--- a/scripts/tests/test_community_notes_ui.py
+++ b/scripts/tests/test_community_notes_ui.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+APP_HTML = ROOT / "app" / "index.html"
+
+
+def app_html() -> str:
+    return APP_HTML.read_text(encoding="utf-8")
+
+
+def test_critical_categories_render_as_critical_alerts():
+    html = app_html()
+
+    for category in ("closed", "wrong_unit", "pin_fix"):
+        assert f"categories.indexOf('{category}')" in html
+    assert "severity: 'critical'" in html
+    assert 'role="note" aria-label="Alerta da comunidade"' in html
+
+
+def test_community_alert_precedes_directions_and_actions():
+    html = app_html()
+    card_render = html[html.index("function renderCard(") : html.index("// ===== RENDER LIST =====")]
+
+    alert_position = card_render.index("renderCommunityRelatos(h.community_notes, reportUrl)")
+    map_position = card_render.index("mapBlockHtml +")
+    actions_position = card_render.index("'<div class=\"actions\">'")
+
+    assert alert_position < map_position < actions_position
+
+
+def test_community_alert_precedes_map_popup_phone_and_directions():
+    html = app_html()
+    map_render = html[html.index("function renderMap()") : html.index("// ===== EVENT HANDLERS =====")]
+
+    alert_position = map_render.index("renderCommunityRelatos(h.community_notes, reportFormUrl(h))")
+    phone_position = map_render.index("phonesHtml ? phonesHtml")
+    directions_position = map_render.index("www.google.com/maps/dir/")
+
+    assert alert_position < phone_position < directions_position
+
+
+def test_alert_heading_uses_valid_block_structure():
+    html = app_html()
+
+    assert '<div><span class="community-alert-eyebrow">' in html
+    assert '<h4 class="community-alert-title">' in html
+    assert '<span><span class="community-alert-eyebrow">' not in html
+
+
+def test_alert_copy_avoids_stale_report_counts_and_keeps_safety_guidance():
+    html = app_html()
+
+    assert "formatCommunitySummary" in html
+    assert r"^relatos? da comunidade(?: \(\d+ relatos?\))?:\s*" in html
+    assert "Antes de ir:" in html
+    assert "ligue 192 ou 193" in html
+    assert "n&atilde;o confirmado pelo Minist&eacute;rio da Sa&uacute;de" in html
+    assert "A situa&ccedil;&atilde;o mudou? Avise o SoroJ&aacute;" in html

--- a/scripts/tests/test_community_notes_ui.py
+++ b/scripts/tests/test_community_notes_ui.py
@@ -24,7 +24,7 @@ def test_community_alert_precedes_directions_and_actions():
     html = app_html()
     card_render = html[html.index("function renderCard(") : html.index("// ===== RENDER LIST =====")]
 
-    alert_position = card_render.index("renderCommunityRelatos(h.community_notes, reportUrl)")
+    alert_position = card_render.index("renderCommunityRelatos(communityNotesForHospital(h), reportUrl)")
     map_position = card_render.index("mapBlockHtml +")
     actions_position = card_render.index("'<div class=\"actions\">'")
 
@@ -35,7 +35,7 @@ def test_community_alert_precedes_map_popup_phone_and_directions():
     html = app_html()
     map_render = html[html.index("function renderMap()") : html.index("// ===== EVENT HANDLERS =====")]
 
-    alert_position = map_render.index("renderCommunityRelatos(h.community_notes, reportFormUrl(h))")
+    alert_position = map_render.index("renderCommunityRelatos(communityNotesForHospital(h), reportFormUrl(h))")
     phone_position = map_render.index("phonesHtml ? phonesHtml")
     directions_position = map_render.index("www.google.com/maps/dir/")
 
@@ -59,3 +59,15 @@ def test_alert_copy_avoids_stale_report_counts_and_keeps_safety_guidance():
     assert "ligue 192 ou 193" in html
     assert "n&atilde;o confirmado pelo Minist&eacute;rio da Sa&uacute;de" in html
     assert "A situa&ccedil;&atilde;o mudou? Avise o SoroJ&aacute;" in html
+
+
+def test_legacy_community_notes_use_the_same_always_visible_alert():
+    html = app_html()
+
+    assert "function isLegacyCommunityNote(note)" in html
+    assert "function communityNotesForHospital(h)" in html
+    assert "renderCommunityRelatos(communityNotesForHospital(h), reportUrl)" in html
+    assert "renderCommunityRelatos(communityNotesForHospital(h), reportFormUrl(h))" in html
+    assert "if (!note || isLegacyCommunityNote(note)) return '';" in html
+    assert '<details class="community-alert' not in html
+    assert '<summary class="community-alert' not in html


### PR DESCRIPTION
## Summary
- render closure, wrong-unit, and pin reports as critical pre-action alerts
- keep contact and other reports as a distinct advisory state
- show the same warning before phone and directions in list cards and full-map popups
- remove stale report-count prefixes from displayed summaries and invite users to report changed conditions
- add regression checks for category severity, semantic structure, and action ordering

## Safety
Official Ministry/SES hospital fields are unchanged. Community information remains explicitly labeled as unconfirmed, with 192/193 guidance and no reporter details.

## Verification
- 39 Python tests passed
- community notes and 2,276 hospital records validated
- generated artifact invariants passed
- inline JavaScript parsed successfully
- mobile and desktop, light and dark, card and full-map popup verified in a browser

Origin: Buzz channel SoroJá (c30659c1-8f68-42a1-b5d5-403c92de4fc6)