### PR TITLE
Publish official temporary Canoas antivenom route

### DIFF
--- a/.github/workflows/rebuild-hospitals-on-override.yml
+++ b/.github/workflows/rebuild-hospitals-on-override.yml
@@ -11,6 +11,7 @@ on:
     paths:
       - "data/location_overrides.json"
       - "data/community_notes.json"
+      - "data/official_temporary_units.json"
   workflow_dispatch: {}
 
 permissions:

--- a/app/hospitals.json
+++ b/app/hospitals.json
@@ -50469,13 +50469,7 @@
     "city": "Canoas",
     "hospital_name": "Hospital de Pronto Socorro de Canoas",
     "address": "Rua Caçapava, 100, Mathias Velho",
-    "community_notes": [
-      {
-        "category": "closed",
-        "reported_at": "2026-04-23",
-        "public_summary": "Relato da comunidade (2 relatos): confirmação de que o HPS continua fechado."
-      }
-    ],
+    "note": "Informação oficial da SES-RS (07/08/2026): o HPS Canoas está temporariamente fechado. Durante a reforma, os pacientes estão sendo atendidos no Hospital Nossa Senhora das Graças (CNES 2232014), que passará a receber soro antiescorpiônico. Confirme antes de se deslocar.",
     "phones": [
       "(51) 3415 4500"
     ],
@@ -63987,6 +63981,28 @@
     "source_date": "2026-07-03",
     "lat": -6.4132101,
     "lng": -48.5321256,
+    "geocode_tier": 1
+  },
+  {
+    "state": "RS",
+    "state_name": "Rio Grande do Sul",
+    "city": "Canoas",
+    "hospital_name": "Hospital Nossa Senhora das Graças",
+    "address": "Av. Santos Ferreira, 1864, Marechal Rondon",
+    "note": "Referência temporária informada pela SES-RS em 07/08/2026 enquanto o HPS Canoas permanece fechado para reforma. A unidade passará a receber soro antiescorpiônico; confirme a disponibilidade antes do deslocamento.",
+    "phones": [
+      "(51) 2102-1000"
+    ],
+    "cnes": "2232014",
+    "antivenoms": [
+      "Escorpiônico"
+    ],
+    "source_antivenoms_raw": [
+      "Escorpiônico"
+    ],
+    "source_date": "2026-08-07",
+    "lat": -29.9271746,
+    "lng": -51.1615711,
     "geocode_tier": 1
   }
 ]

--- a/data/community_notes.json
+++ b/data/community_notes.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-06-27",
+  "generated_at": "2026-08-10",
   "notes": {
     "2585367": [
       {
@@ -20,13 +20,6 @@
         "category": "wrong_unit",
         "reported_at": "2026-04-25",
         "public_summary": "Relato da comunidade: o pronto-socorro foi substituído neste endereço; agora funciona uma UPA na Rua Quim Quevedo, nº 56."
-      }
-    ],
-    "3626245": [
-      {
-        "category": "closed",
-        "reported_at": "2026-04-23",
-        "public_summary": "Relato da comunidade (2 relatos): confirmação de que o HPS continua fechado."
       }
     ],
     "2801566": [

--- a/data/location_overrides.json
+++ b/data/location_overrides.json
@@ -119,5 +119,10 @@
     "reason": "Hospital Municipal Gumercino Barbosa (Alto Paraíso de Goiás/GO) — relato comunitário (15/07/2026) informando que a unidade está sem soro em estoque no momento.",
     "verified_on": "2026-07-15",
     "note": "Relato comunitário (15/07/2026): no momento o hospital está sem soro em estoque. Confirme por telefone antes de se deslocar."
+  },
+  "3626245": {
+    "reason": "SES-RS confirmou em 07/08/2026 que o HPS Canoas está temporariamente fechado e que o atendimento ocorre no Hospital Nossa Senhora das Graças (CNES 2232014), que passará a receber soro antiescorpiônico até o fim da reforma.",
+    "verified_on": "2026-08-07",
+    "note": "Informação oficial da SES-RS (07/08/2026): o HPS Canoas está temporariamente fechado. Durante a reforma, os pacientes estão sendo atendidos no Hospital Nossa Senhora das Graças (CNES 2232014), que passará a receber soro antiescorpiônico. Confirme antes de se deslocar."
   }
 }

--- a/data/official_temporary_units.json
+++ b/data/official_temporary_units.json
@@ -1,0 +1,22 @@
+{
+  "generated_at": "2026-08-10",
+  "units": [
+    {
+      "state": "RS",
+      "state_name": "Rio Grande do Sul",
+      "city": "Canoas",
+      "hospital_name": "Hospital Nossa Senhora das Graças",
+      "address": "Av. Santos Ferreira, 1864, Marechal Rondon",
+      "phones": ["(51) 2102-1000"],
+      "cnes": "2232014",
+      "antivenoms": ["Escorpiônico"],
+      "source_date": "2026-08-07",
+      "source_authority": "Área Técnica da Vigilância dos Acidentes por Animais Peçonhentos / SES-RS",
+      "lat": -29.9271746,
+      "lng": -51.1615711,
+      "geocode_tier": 1,
+      "coordinate_source": "Hospital address matched to the OpenStreetMap hospital footprint and checked on 2026-08-10.",
+      "note": "Referência temporária informada pela SES-RS em 07/08/2026 enquanto o HPS Canoas permanece fechado para reforma. A unidade passará a receber soro antiescorpiônico; confirme a disponibilidade antes do deslocamento."
+    }
+  ]
+}

--- a/docs/PROCESS.md
+++ b/docs/PROCESS.md
@@ -547,6 +547,23 @@ re-publish, or set its `expires_at` to a past date.
 
 ---
 
+## Official temporary units (additive layer)
+
+Time-sensitive routing confirmed directly by a state or municipal health
+authority belongs in `data/official_temporary_units.json` when the destination
+is not yet present in the canonical Ministry/state workbook. This layer is for
+temporary operational arrangements only; it must not imply live stock or
+silently rewrite the canonical source extract.
+
+Each unit records the authority, evidence date, CNES, public contact details,
+the specifically confirmed antivenom types, manually checked coordinates and
+conservative public wording. `scripts/build_app_hospitals_json.py` appends the
+records to the generated public JSON and refuses duplicate CNES values. Remove
+the temporary record when the authority confirms that the arrangement ended or
+a newer canonical workbook incorporates the destination.
+
+---
+
 ## Appendix A — handling the review queue
 
 `build/review_queue_v1.csv` contains 684 rows today:

--- a/hospitals.json
+++ b/hospitals.json
@@ -50469,13 +50469,7 @@
     "city": "Canoas",
     "hospital_name": "Hospital de Pronto Socorro de Canoas",
     "address": "Rua Caçapava, 100, Mathias Velho",
-    "community_notes": [
-      {
-        "category": "closed",
-        "reported_at": "2026-04-23",
-        "public_summary": "Relato da comunidade (2 relatos): confirmação de que o HPS continua fechado."
-      }
-    ],
+    "note": "Informação oficial da SES-RS (07/08/2026): o HPS Canoas está temporariamente fechado. Durante a reforma, os pacientes estão sendo atendidos no Hospital Nossa Senhora das Graças (CNES 2232014), que passará a receber soro antiescorpiônico. Confirme antes de se deslocar.",
     "phones": [
       "(51) 3415 4500"
     ],
@@ -63987,6 +63981,28 @@
     "source_date": "2026-07-03",
     "lat": -6.4132101,
     "lng": -48.5321256,
+    "geocode_tier": 1
+  },
+  {
+    "state": "RS",
+    "state_name": "Rio Grande do Sul",
+    "city": "Canoas",
+    "hospital_name": "Hospital Nossa Senhora das Graças",
+    "address": "Av. Santos Ferreira, 1864, Marechal Rondon",
+    "note": "Referência temporária informada pela SES-RS em 07/08/2026 enquanto o HPS Canoas permanece fechado para reforma. A unidade passará a receber soro antiescorpiônico; confirme a disponibilidade antes do deslocamento.",
+    "phones": [
+      "(51) 2102-1000"
+    ],
+    "cnes": "2232014",
+    "antivenoms": [
+      "Escorpiônico"
+    ],
+    "source_antivenoms_raw": [
+      "Escorpiônico"
+    ],
+    "source_date": "2026-08-07",
+    "lat": -29.9271746,
+    "lng": -51.1615711,
     "geocode_tier": 1
   }
 ]

--- a/scripts/build_app_hospitals_json.py
+++ b/scripts/build_app_hospitals_json.py
@@ -45,6 +45,7 @@ OUT_APP = ROOT / "app" / "hospitals.json"
 OUT_ROOT = ROOT / "hospitals.json"
 OVERRIDES = ROOT / "data" / "location_overrides.json"
 COMMUNITY_NOTES = ROOT / "data" / "community_notes.json"
+OFFICIAL_TEMPORARY_UNITS = ROOT / "data" / "official_temporary_units.json"
 SOURCE_DATES = ROOT / "data" / "source_dates.json"
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
@@ -174,6 +175,63 @@ def load_community_notes() -> dict[str, list[dict]]:
     return notes
 
 
+def load_official_temporary_units(
+    path: Path = OFFICIAL_TEMPORARY_UNITS,
+) -> list[dict]:
+    """Load temporary units confirmed directly by a health authority.
+
+    This separate layer keeps newer operational routing traceable without
+    making a temporary destination look like a permanent source record.
+    """
+    if not path.exists():
+        return []
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict) or not isinstance(data.get("units"), list):
+        raise ValueError(f"{path} must contain an object with a units array")
+    return data["units"]
+
+
+def build_official_temporary_record(unit: dict, index: int) -> dict:
+    ctx = f"official temporary unit {index}"
+    required = {
+        "state", "state_name", "city", "hospital_name", "address", "phones",
+        "cnes", "antivenoms", "source_date", "source_authority", "lat", "lng",
+        "geocode_tier", "note",
+    }
+    missing = sorted(key for key in required if unit.get(key) in (None, "", []))
+    if missing:
+        raise ValueError(f"{ctx} missing required field(s): {', '.join(missing)}")
+
+    cnes = str(unit["cnes"]).strip()
+    if not cnes.isdigit():
+        raise ValueError(f"{ctx} has invalid CNES {cnes!r}")
+    if not isinstance(unit["phones"], list):
+        raise ValueError(f"{ctx} phones must be an array")
+    if not isinstance(unit["antivenoms"], list):
+        raise ValueError(f"{ctx} antivenoms must be an array")
+
+    canon_result = canonicalize_list([str(value) for value in unit["antivenoms"]])
+    if canon_result.unknown or canon_result.leaks or canon_result.other_soros:
+        raise ValueError(f"{ctx} contains unsupported antivenom values")
+
+    return {
+        "state": str(unit["state"]).strip().upper(),
+        "state_name": str(unit["state_name"]).strip(),
+        "city": str(unit["city"]).strip(),
+        "hospital_name": str(unit["hospital_name"]).strip(),
+        "address": str(unit["address"]).strip(),
+        "note": str(unit["note"]).strip(),
+        "phones": [str(value).strip() for value in unit["phones"] if str(value).strip()],
+        "cnes": cnes,
+        "antivenoms": canon_result.canonical,
+        "source_antivenoms_raw": [str(value).strip() for value in unit["antivenoms"]],
+        "source_date": str(unit["source_date"]).strip(),
+        "lat": float(unit["lat"]),
+        "lng": float(unit["lng"]),
+        "geocode_tier": int(unit["geocode_tier"]),
+    }
+
+
 def _is_expired(note: dict, today: date) -> bool:
     expires = (note.get("expires_at") or "").strip()
     if not expires:
@@ -202,6 +260,7 @@ def main() -> int:
     pdf_dates = load_pdf_date_map()
     overrides = load_overrides()
     community_notes = load_community_notes()
+    official_temporary_units = load_official_temporary_units()
     today = date.today()
     overrides_applied: list[str] = []
     overrides_hidden: list[str] = []
@@ -313,6 +372,20 @@ def main() -> int:
             published_cnes.add(cnes)
         out_records.append(record)
 
+    temporary_units_added = 0
+    for index, unit in enumerate(official_temporary_units, start=1):
+        if not isinstance(unit, dict):
+            raise ValueError(f"official temporary unit {index} must be an object")
+        record = build_official_temporary_record(unit, index)
+        cnes = record["cnes"]
+        if cnes in published_cnes:
+            raise ValueError(
+                f"official temporary unit {index} duplicates published CNES {cnes}"
+            )
+        out_records.append(record)
+        published_cnes.add(cnes)
+        temporary_units_added += 1
+
     for cnes in overrides:
         if cnes not in published_cnes:
             overrides_unknown.append(cnes)
@@ -353,6 +426,7 @@ def main() -> int:
     print(f"Published (publish_policy == publish):   {len(rows):,}")
     print(f"Hidden (state-only / muni-mismatch / external-review): {hidden:,}")
     print(f"Overrides applied: {len(overrides_applied)}")
+    print(f"Official temporary units added: {temporary_units_added}")
     if overrides_hidden:
         print(f"Overrides hidden: {len(overrides_hidden)} ({', '.join(overrides_hidden)})")
     if overrides_unknown:

--- a/scripts/rebuild_final_artifacts.py
+++ b/scripts/rebuild_final_artifacts.py
@@ -39,6 +39,7 @@ OUT_SHEETS_REVIEW = BUILD / "google_sheets_review_queue_v1.csv"
 OUT_APP = ROOT / "app" / "hospitals.json"
 OUT_ROOT = ROOT / "hospitals.json"
 OVERRIDES = DATA / "location_overrides.json"
+OFFICIAL_TEMPORARY_UNITS = DATA / "official_temporary_units.json"
 REPORT = REPORTS / "10_google_sheets_export_summary.md"
 
 REVIEW_STATUSES = {"watchlist", "retry_queue", "manual_review_pending_external"}
@@ -123,6 +124,14 @@ def load_hidden_override_cnes() -> set[str]:
     return {str(cnes) for cnes, value in data.items() if isinstance(value, dict) and value.get("hide")}
 
 
+def load_official_temporary_cnes() -> list[str]:
+    if not OFFICIAL_TEMPORARY_UNITS.exists():
+        return []
+    data = json.loads(OFFICIAL_TEMPORARY_UNITS.read_text(encoding="utf-8"))
+    units = data.get("units", []) if isinstance(data, dict) else []
+    return [str(unit.get("cnes", "")) for unit in units if isinstance(unit, dict)]
+
+
 def row_has_coords(row: dict[str, str]) -> bool:
     try:
         float(row.get("lat", ""))
@@ -173,16 +182,19 @@ def validate_artifacts(master_rows: list[dict[str, str]], include_app_json: bool
             and row_has_coords(r)
             and str(r.get("cnes", "")) not in hidden_cnes
         ]
-        if len(app_data) != len(expected_app_rows):
+        temporary_cnes = load_official_temporary_cnes()
+        if len(app_data) != len(expected_app_rows) + len(temporary_cnes):
             errors.append(
                 "app/hospitals.json row count does not match publish_policy=publish "
-                "minus hidden overrides"
+                "minus hidden overrides plus official temporary units"
             )
         app_cnes = Counter(str(row.get("cnes", "")) for row in app_data)
         expected_cnes = Counter(str(row.get("cnes", "")) for row in expected_app_rows)
+        expected_cnes.update(temporary_cnes)
         if app_cnes != expected_cnes:
             errors.append(
-                "app/hospitals.json CNES multiset does not match published master rows"
+                "app/hospitals.json CNES multiset does not match published master rows "
+                "plus official temporary units"
             )
 
     return errors

--- a/scripts/tests/test_official_temporary_units.py
+++ b/scripts/tests/test_official_temporary_units.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import sys
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import build_app_hospitals_json as builder  # noqa: E402
+
+
+def test_load_and_build_official_temporary_unit(tmp_path: Path):
+    path = tmp_path / "official_temporary_units.json"
+    path.write_text(
+        json.dumps(
+            {
+                "generated_at": "2026-08-10",
+                "units": [
+                    {
+                        "state": "RS",
+                        "state_name": "Rio Grande do Sul",
+                        "city": "Canoas",
+                        "hospital_name": "Hospital Nossa Senhora das Graças",
+                        "address": "Av. Santos Ferreira, 1864, Marechal Rondon",
+                        "phones": ["(51) 2102-1000"],
+                        "cnes": "2232014",
+                        "antivenoms": ["Escorpiônico"],
+                        "source_date": "2026-08-07",
+                        "source_authority": "SES-RS",
+                        "lat": -29.9271746,
+                        "lng": -51.1615711,
+                        "geocode_tier": 1,
+                        "note": "Referência temporária; confirme antes de se deslocar.",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    units = builder.load_official_temporary_units(path)
+    record = builder.build_official_temporary_record(units[0], 1)
+
+    assert record["cnes"] == "2232014"
+    assert record["antivenoms"] == ["Escorpiônico"]
+    assert record["source_date"] == "2026-08-07"
+
+
+def test_rejects_incomplete_official_temporary_unit():
+    with pytest.raises(ValueError, match="missing required field"):
+        builder.build_official_temporary_record({"cnes": "2232014"}, 1)


### PR DESCRIPTION
## What changed

- adds Hospital Nossa Senhora das Graças (CNES 2232014) as a temporary Canoas card for antiscorpion serum only
- adds the official SES-RS temporary-closure and routing note to HPS Canoas (CNES 3626245)
- removes the superseded community-only HPS closure alert
- introduces a traceable official-temporary-unit layer so future source refreshes preserve the arrangement without presenting it as permanent or as live stock

## Evidence boundary

SES-RS confirmed on 2026-08-07 that HPS Canoas is temporarily closed, patients are being attended at Hospital Nossa Senhora das Graças, and that hospital will receive antiscorpion serum until the HPS renovation is completed. The public wording tells users to confirm availability before traveling.

## Validation

- `python3 scripts/build_app_hospitals_json.py`
- `python3 scripts/validate_hospitals_json.py app/hospitals.json`
- `python3 scripts/validate_location_overrides.py`
- `python3 scripts/validate_community_notes.py`
- `python3 scripts/rebuild_final_artifacts.py --check`
- `python3 -m pytest scripts/tests/ -q` — 42 passed
- `npm run format:check`
- `git diff --check`