### PR TITLE
Attribute temporary Canoas card to SES-RS

### DIFF
--- a/app/hospitals.json
+++ b/app/hospitals.json
@@ -64001,6 +64001,8 @@
       "Escorpiônico"
     ],
     "source_date": "2026-08-07",
+    "source_label": "SES-RS",
+    "source_url": "https://saude.rs.gov.br/",
     "lat": -29.9271746,
     "lng": -51.1615711,
     "geocode_tier": 1

--- a/app/index.html
+++ b/app/index.html
@@ -1421,8 +1421,10 @@
         var sourceHtml;
         if (h.source_date) {
             var dateFormatted = escapeHtml(h.source_date.split('-').reverse().join('/'));
+            var sourceLabel = escapeHtml(h.source_label || 'MS');
+            var sourceUrl = escapeHtml(h.source_url || 'https://www.gov.br/saude/pt-br/assuntos/saude-de-a-a-z/a/animais-peconhentos/hospitais-de-referencia');
             sourceHtml = '<div class="source-date">Atualizado ' + dateFormatted +
-                ' — <a href="https://www.gov.br/saude/pt-br/assuntos/saude-de-a-a-z/a/animais-peconhentos/hospitais-de-referencia" target="_blank" rel="noopener">Fonte: MS</a>' +
+                ' — <a href="' + sourceUrl + '" target="_blank" rel="noopener">Fonte: ' + sourceLabel + '</a>' +
                 reportLinkHtml +
                 '</div>';
         } else {

--- a/data/official_temporary_units.json
+++ b/data/official_temporary_units.json
@@ -12,6 +12,8 @@
       "antivenoms": ["Escorpiônico"],
       "source_date": "2026-08-07",
       "source_authority": "Área Técnica da Vigilância dos Acidentes por Animais Peçonhentos / SES-RS",
+      "source_label": "SES-RS",
+      "source_url": "https://saude.rs.gov.br/",
       "lat": -29.9271746,
       "lng": -51.1615711,
       "geocode_tier": 1,

--- a/hospitals.json
+++ b/hospitals.json
@@ -64001,6 +64001,8 @@
       "Escorpiônico"
     ],
     "source_date": "2026-08-07",
+    "source_label": "SES-RS",
+    "source_url": "https://saude.rs.gov.br/",
     "lat": -29.9271746,
     "lng": -51.1615711,
     "geocode_tier": 1

--- a/scripts/build_app_hospitals_json.py
+++ b/scripts/build_app_hospitals_json.py
@@ -195,8 +195,8 @@ def build_official_temporary_record(unit: dict, index: int) -> dict:
     ctx = f"official temporary unit {index}"
     required = {
         "state", "state_name", "city", "hospital_name", "address", "phones",
-        "cnes", "antivenoms", "source_date", "source_authority", "lat", "lng",
-        "geocode_tier", "note",
+        "cnes", "antivenoms", "source_date", "source_authority", "source_label",
+        "source_url", "lat", "lng", "geocode_tier", "note",
     }
     missing = sorted(key for key in required if unit.get(key) in (None, "", []))
     if missing:
@@ -226,6 +226,8 @@ def build_official_temporary_record(unit: dict, index: int) -> dict:
         "antivenoms": canon_result.canonical,
         "source_antivenoms_raw": [str(value).strip() for value in unit["antivenoms"]],
         "source_date": str(unit["source_date"]).strip(),
+        "source_label": str(unit["source_label"]).strip(),
+        "source_url": str(unit["source_url"]).strip(),
         "lat": float(unit["lat"]),
         "lng": float(unit["lng"]),
         "geocode_tier": int(unit["geocode_tier"]),
@@ -414,6 +416,10 @@ def main() -> int:
                 rebuilt["community_notes"] = rec["community_notes"]
             if k == "source_antivenoms_raw" and "other_soros" in rec:
                 rebuilt["other_soros"] = rec["other_soros"]
+            if k == "source_date":
+                for optional_key in ("source_label", "source_url"):
+                    if rec.get(optional_key):
+                        rebuilt[optional_key] = rec[optional_key]
         return rebuilt
     ordered = [_order(rec) for rec in out_records]
 

--- a/scripts/tests/test_official_source_label.py
+++ b/scripts/tests/test_official_source_label.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+def test_hospital_cards_support_non_ministry_source_labels():
+    index = (ROOT / "app" / "index.html").read_text(encoding="utf-8")
+
+    assert "h.source_label || 'MS'" in index
+    assert "h.source_url ||" in index
+    assert ">Fonte: ' + sourceLabel" in index

--- a/scripts/tests/test_official_temporary_units.py
+++ b/scripts/tests/test_official_temporary_units.py
@@ -29,6 +29,8 @@ def test_load_and_build_official_temporary_unit(tmp_path: Path):
                         "antivenoms": ["Escorpiônico"],
                         "source_date": "2026-08-07",
                         "source_authority": "SES-RS",
+                        "source_label": "SES-RS",
+                        "source_url": "https://saude.rs.gov.br/",
                         "lat": -29.9271746,
                         "lng": -51.1615711,
                         "geocode_tier": 1,
@@ -46,6 +48,8 @@ def test_load_and_build_official_temporary_unit(tmp_path: Path):
     assert record["cnes"] == "2232014"
     assert record["antivenoms"] == ["Escorpiônico"]
     assert record["source_date"] == "2026-08-07"
+    assert record["source_label"] == "SES-RS"
+    assert record["source_url"] == "https://saude.rs.gov.br/"
 
 
 def test_rejects_incomplete_official_temporary_unit():


### PR DESCRIPTION
## What changed

- makes hospital-card source labels data-driven
- attributes the temporary Hospital Nossa Senhora das Graças card to SES-RS rather than the default Ministry source label
- links that card's source footer to the SES-RS public site
- preserves the existing `Fonte: MS` behavior for canonical Ministry records

## Why

Production browser verification of PR #41 found that the new card data was correct but its footer inherited the hard-coded `Fonte: MS` label. The operational evidence is from SES-RS and must be attributed accurately.

## Validation

- rebuilt and validated both hospital JSON artifacts
- final artifact invariants passed
- 43 pytest tests passed
- Prettier and `git diff --check` passed