### PR TITLE
fix(data): restore Canoas community alert

### DIFF
--- a/app/hospitals.json
+++ b/app/hospitals.json
@@ -50470,6 +50470,13 @@
     "hospital_name": "Hospital de Pronto Socorro de Canoas",
     "address": "Rua Caçapava, 100, Mathias Velho",
     "note": "Informação oficial da SES-RS (07/08/2026): o HPS Canoas está temporariamente fechado. Durante a reforma, os pacientes estão sendo atendidos no Hospital Nossa Senhora das Graças (CNES 2232014), que passará a receber soro antiescorpiônico. Confirme antes de se deslocar.",
+    "community_notes": [
+      {
+        "category": "closed",
+        "reported_at": "2026-04-23",
+        "public_summary": "Relato da comunidade (2 relatos): confirmação de que o HPS continua fechado."
+      }
+    ],
     "phones": [
       "(51) 3415 4500"
     ],

--- a/data/community_notes.json
+++ b/data/community_notes.json
@@ -22,6 +22,13 @@
         "public_summary": "Relato da comunidade: o pronto-socorro foi substituído neste endereço; agora funciona uma UPA na Rua Quim Quevedo, nº 56."
       }
     ],
+    "3626245": [
+      {
+        "category": "closed",
+        "reported_at": "2026-04-23",
+        "public_summary": "Relato da comunidade (2 relatos): confirmação de que o HPS continua fechado."
+      }
+    ],
     "2801566": [
       {
         "category": "contact_fix",

--- a/hospitals.json
+++ b/hospitals.json
@@ -50470,6 +50470,13 @@
     "hospital_name": "Hospital de Pronto Socorro de Canoas",
     "address": "Rua Caçapava, 100, Mathias Velho",
     "note": "Informação oficial da SES-RS (07/08/2026): o HPS Canoas está temporariamente fechado. Durante a reforma, os pacientes estão sendo atendidos no Hospital Nossa Senhora das Graças (CNES 2232014), que passará a receber soro antiescorpiônico. Confirme antes de se deslocar.",
+    "community_notes": [
+      {
+        "category": "closed",
+        "reported_at": "2026-04-23",
+        "public_summary": "Relato da comunidade (2 relatos): confirmação de que o HPS continua fechado."
+      }
+    ],
     "phones": [
       "(51) 3415 4500"
     ],

--- a/scripts/tests/test_canoas_community_alert.py
+++ b/scripts/tests/test_canoas_community_alert.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+COMMUNITY_NOTES = ROOT / "data" / "community_notes.json"
+HOSPITALS = ROOT / "app" / "hospitals.json"
+
+
+def test_canoas_hps_keeps_structured_community_alert():
+    notes = json.loads(COMMUNITY_NOTES.read_text(encoding="utf-8"))["notes"]
+    canoas_notes = notes["3626245"]
+
+    assert canoas_notes == [
+        {
+            "category": "closed",
+            "reported_at": "2026-04-23",
+            "public_summary": (
+                "Relato da comunidade (2 relatos): confirmação de que o HPS "
+                "continua fechado."
+            ),
+        }
+    ]
+
+
+def test_canoas_hps_generated_card_contains_new_alert_data():
+    hospitals = json.loads(HOSPITALS.read_text(encoding="utf-8"))
+    canoas = next(h for h in hospitals if h.get("cnes") == "3626245")
+
+    assert canoas["community_notes"][0]["category"] == "closed"
+    assert "2 relatos" in canoas["community_notes"][0]["public_summary"]
+    assert canoas["note"].startswith("Informação oficial da SES-RS")


### PR DESCRIPTION
## What changed

- restores the structured two-report Canoas HPS community alert
- keeps the SES-RS official routing note as a separate trust layer
- adds regression coverage so the generated card cannot silently lose the new alert format

## Root cause

The prior release removed the structured `community_notes` entry while promoting the verified SES-RS information into an inline official note. That caused the community warning to lose the new always-visible critical alert treatment.

## Validation

- community-note validator passed
- final artifact invariants passed
- 45 pytest tests passed
- Prettier and diff checks passed
- browser verified the critical community alert appears before card actions