### PR TITLE
fix(ui): replace yellow hospital notes with red alerts

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -84,10 +84,6 @@
             --community-critical-border: #E11D48;
             --community-critical-title: #9F1239;
             --community-critical-text: #881337;
-            --community-advisory-bg: #FFFBEB;
-            --community-advisory-border: #D97706;
-            --community-advisory-title: #92400E;
-            --community-advisory-text: #78350F;
         }
 
         [data-theme="dark"] {
@@ -131,10 +127,6 @@
             --community-critical-border: #FB7185;
             --community-critical-title: #FDA4AF;
             --community-critical-text: #FFE4E6;
-            --community-advisory-bg: #422006;
-            --community-advisory-border: #F59E0B;
-            --community-advisory-title: #FCD34D;
-            --community-advisory-text: #FEF3C7;
         }
 
         * { box-sizing: border-box; margin: 0; padding: 0; font-family: 'Outfit', sans-serif; -webkit-tap-highlight-color: transparent; }
@@ -367,14 +359,8 @@
         .card-header > div:first-child { min-width: 0; flex: 1; }
         .card .city { font-size: 14px; color: var(--text-muted); margin-bottom: 6px; font-weight: 600; }
         .card .address { font-size: 13px; color: var(--text-muted); line-height: 1.45; margin-bottom: 6px; }
-        .card .hospital-note {
-            margin-top: 6px; padding: 8px 10px; background: rgba(245,158,11,0.1);
-            border: 1px solid rgba(245,158,11,0.3); border-left: 3px solid #F59E0B;
-            border-radius: 8px; font-size: 12px; color: #FCD34D; line-height: 1.45;
-            white-space: pre-line;
-        }
-        /* Community reports are a separate trust layer. Critical service or
-           location warnings must interrupt the path to directions/actions. */
+        /* Hospital alerts always use the critical red treatment and interrupt
+           the path to directions/actions. Legacy amber boxes are retired. */
         .community-alert {
             margin-top: 16px; padding: 16px; border: 2px solid;
             border-radius: 16px; font-size: 14px; line-height: 1.5;
@@ -384,11 +370,6 @@
             border-color: var(--community-critical-border);
             color: var(--community-critical-text);
         }
-        .community-alert-advisory {
-            background: var(--community-advisory-bg);
-            border-color: var(--community-advisory-border);
-            color: var(--community-advisory-text);
-        }
         .community-alert-header { display: flex; align-items: center; gap: 10px; margin-bottom: 10px; }
         .community-alert-icon {
             width: 32px; height: 32px; border-radius: 50%; flex: 0 0 32px;
@@ -396,16 +377,14 @@
             color: white; background: var(--community-critical-border);
             font-size: 20px; font-weight: 900;
         }
-        .community-alert-advisory .community-alert-icon { background: var(--community-advisory-border); }
         .community-alert-eyebrow {
             display: block; font-size: 11px; font-weight: 900;
             text-transform: uppercase; letter-spacing: 0.7px;
         }
         .community-alert-critical .community-alert-eyebrow,
         .community-alert-critical .community-alert-title { color: var(--community-critical-title); }
-        .community-alert-advisory .community-alert-eyebrow,
-        .community-alert-advisory .community-alert-title { color: var(--community-advisory-title); }
         .community-alert-title { margin: 0; font-size: 16px; line-height: 1.25; }
+        .official-alert-message { white-space: pre-line; }
         .community-relato { margin-bottom: 8px; }
         .community-relato:last-of-type { margin-bottom: 0; }
         .community-relato .relato-date {
@@ -1024,8 +1003,7 @@
             .replace(/'/g, '&#39;');
     }
 
-    // Render a maintainer/official override note. Legacy community-sourced
-    // override notes are routed through the always-visible alert below.
+    // Render a maintainer/official override note inside the red alert component.
     function formatHospitalNote(note) {
         if (note == null) return '';
         var safe = escapeHtml(note);
@@ -1067,9 +1045,20 @@
         return notes;
     }
 
+    function officialAlertTitle(note) {
+        return /SES-RS/i.test(String(note || '')) ? 'Orienta\u00e7\u00e3o da SES-RS' : 'Informa\u00e7\u00e3o importante';
+    }
+
     function renderHospitalNote(note) {
         if (!note || isLegacyCommunityNote(note)) return '';
-        return '<div class="hospital-note">' + formatHospitalNote(note) + '</div>';
+        return '<section class="community-alert community-alert-critical official-alert" role="alert" aria-label="Alerta oficial">' +
+            '<div class="community-alert-header">' +
+                '<span class="community-alert-icon" aria-hidden="true">!</span>' +
+                '<div><span class="community-alert-eyebrow">Alerta oficial</span>' +
+                '<h4 class="community-alert-title">' + officialAlertTitle(note) + '</h4></div>' +
+            '</div>' +
+            '<div class="official-alert-message">' + formatHospitalNote(note) + '</div>' +
+        '</section>';
     }
 
     function haversine(lat1, lon1, lat2, lon2) {
@@ -1298,7 +1287,7 @@
         if (categories.indexOf('pin_fix') !== -1) {
             return { severity: 'critical', title: 'Localiza\u00e7\u00e3o questionada' };
         }
-        return { severity: 'advisory', title: 'Informa\u00e7\u00e3o da comunidade' };
+        return { severity: 'critical', title: 'Informa\u00e7\u00e3o da comunidade' };
     }
 
     function formatCommunitySummary(summary) {
@@ -1333,6 +1322,12 @@
                 '<span class="community-alert-source">Relato da comunidade, n&atilde;o confirmado pelo Minist&eacute;rio da Sa&uacute;de.</span></p>' +
             '<a class="community-alert-report" href="' + escapeHtml(reportUrl) + '" target="_blank" rel="noopener">A situa&ccedil;&atilde;o mudou? Avise o SoroJ&aacute;</a>' +
         '</section>';
+    }
+
+    function renderHospitalAlerts(h, reportUrl) {
+        var officialAlert = renderHospitalNote(h.note);
+        if (officialAlert) return officialAlert;
+        return renderCommunityRelatos(communityNotesForHospital(h), reportUrl);
     }
 
     // ===== RENDER CARD =====
@@ -1437,10 +1432,9 @@
                 '<div><h3>' + escapeHtml(h.hospital_name) + '</h3>' +
                 '<div class="city">' + escapeHtml(h.city) + ', ' + escapeHtml(h.state) + '</div>' +
                 (h.address ? '<div class="address">' + escapeHtml(h.address) + '</div>' : '') +
-                renderHospitalNote(h.note) +
                 '</div>' + distHtml +
             '</div>' +
-            renderCommunityRelatos(communityNotesForHospital(h), reportUrl) +
+            renderHospitalAlerts(h, reportUrl) +
             tagsHtml +
             mapBlockHtml +
             '<div class="actions">' +
@@ -1690,8 +1684,7 @@
             var popup = '<strong>' + escapeHtml(h.hospital_name) + '</strong><br>' +
                 escapeHtml(h.city) + ', ' + escapeHtml(h.state) + distText + '<br>' +
                 popupEmojis +
-                (h.note && !isLegacyCommunityNote(h.note) ? '<em style="color:#B26A00">' + formatHospitalNote(h.note) + '</em><br>' : '') +
-                renderCommunityRelatos(communityNotesForHospital(h), reportFormUrl(h)) +
+                renderHospitalAlerts(h, reportFormUrl(h)) +
                 (phonesHtml ? phonesHtml + '<br>' : '') +
                 '<a href="https://www.google.com/maps/dir/?api=1&destination=' + h.lat + ',' + h.lng +
                 '" target="_blank"><svg width="18" height="18" viewBox="0 0 24 24" fill="white" style="flex-shrink:0"><path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z"/></svg> Como Chegar</a>';

--- a/scripts/tests/test_community_notes_ui.py
+++ b/scripts/tests/test_community_notes_ui.py
@@ -24,7 +24,7 @@ def test_community_alert_precedes_directions_and_actions():
     html = app_html()
     card_render = html[html.index("function renderCard(") : html.index("// ===== RENDER LIST =====")]
 
-    alert_position = card_render.index("renderCommunityRelatos(communityNotesForHospital(h), reportUrl)")
+    alert_position = card_render.index("renderHospitalAlerts(h, reportUrl)")
     map_position = card_render.index("mapBlockHtml +")
     actions_position = card_render.index("'<div class=\"actions\">'")
 
@@ -35,7 +35,7 @@ def test_community_alert_precedes_map_popup_phone_and_directions():
     html = app_html()
     map_render = html[html.index("function renderMap()") : html.index("// ===== EVENT HANDLERS =====")]
 
-    alert_position = map_render.index("renderCommunityRelatos(communityNotesForHospital(h), reportFormUrl(h))")
+    alert_position = map_render.index("renderHospitalAlerts(h, reportFormUrl(h))")
     phone_position = map_render.index("phonesHtml ? phonesHtml")
     directions_position = map_render.index("www.google.com/maps/dir/")
 
@@ -66,8 +66,8 @@ def test_legacy_community_notes_use_the_same_always_visible_alert():
 
     assert "function isLegacyCommunityNote(note)" in html
     assert "function communityNotesForHospital(h)" in html
-    assert "renderCommunityRelatos(communityNotesForHospital(h), reportUrl)" in html
-    assert "renderCommunityRelatos(communityNotesForHospital(h), reportFormUrl(h))" in html
+    assert "renderHospitalAlerts(h, reportUrl)" in html
+    assert "renderHospitalAlerts(h, reportFormUrl(h))" in html
     assert "if (!note || isLegacyCommunityNote(note)) return '';" in html
     assert '<details class="community-alert' not in html
     assert '<summary class="community-alert' not in html

--- a/scripts/tests/test_hospital_alerts_ui.py
+++ b/scripts/tests/test_hospital_alerts_ui.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+APP_HTML = ROOT / "app" / "index.html"
+
+
+def app_html() -> str:
+    return APP_HTML.read_text(encoding="utf-8")
+
+
+def test_yellow_hospital_note_component_is_retired():
+    html = app_html()
+
+    assert ".card .hospital-note" not in html
+    assert 'class="hospital-note"' not in html
+    assert "community-alert-advisory" not in html
+    assert "--community-advisory" not in html
+
+
+def test_hospital_notes_render_as_red_official_alerts():
+    html = app_html()
+
+    assert "function renderHospitalAlerts(h, reportUrl)" in html
+    assert 'class="community-alert community-alert-critical official-alert"' in html
+    assert 'aria-label="Alerta oficial"' in html
+    assert ">Alerta oficial</span>" in html
+    assert "Orienta\\u00e7\\u00e3o da SES-RS" in html
+
+
+def test_official_alert_replaces_duplicate_community_alert():
+    html = app_html()
+    start = html.index("function renderHospitalAlerts(h, reportUrl)")
+    end = html.index("// ===== RENDER CARD =====", start)
+    renderer = html[start:end]
+
+    assert "if (officialAlert) return officialAlert;" in renderer
+    assert "renderCommunityRelatos(communityNotesForHospital(h), reportUrl)" in renderer
+
+
+def test_official_alert_is_full_width_before_actions():
+    html = app_html()
+    card_render = html[html.index("function renderCard(") : html.index("// ===== RENDER LIST =====")]
+
+    header_end = card_render.index("'</div>' +\n            renderHospitalAlerts(h, reportUrl)")
+    alert_position = card_render.index("renderHospitalAlerts(h, reportUrl)")
+    actions_position = card_render.index("'<div class=\"actions\">'")
+
+    assert header_end < alert_position < actions_position


### PR DESCRIPTION
## What changed

- retires the yellow/amber hospital-note component and advisory alert styling
- renders hospital notes as always-visible red critical alerts
- shows one red official SES-RS alert on each Canoas hospital card with the full former yellow-box message
- prioritizes the official alert over a redundant visible community warning while preserving community-report history in data
- applies the same alert renderer to map popups

## Root cause

Official notes still used the legacy inline yellow component, while community reports used the newer red alert component. This created inconsistent hierarchy and duplicate warnings on HPS Canoas.

## Validation

- 49 pytest tests passed
- format and diff checks passed
- regression tests forbid the yellow component/advisory tokens
- browser verified both Canoas cards have exactly one red official alert, zero yellow notes, correct SES-RS messages, and alerts before actions
- no browser error overlay; page content loaded