### PR TITLE
fix(data): correct São Domingos hospital pin

### DIFF
--- a/app/hospitals.json
+++ b/app/hospitals.json
@@ -16785,7 +16785,6 @@
     "city": "São Domingos",
     "hospital_name": "Hospital Municipal de São Domingos",
     "address": "Rua Pedro Matias dos Santos, Qd 10, Lt 01-04 - Setor São Sebastião",
-    "note": "Comunidade reportou (29/04/2026): possível encerramento. Confirme por telefone antes de se deslocar.",
     "phones": [
       "(62) 3425-1598"
     ],
@@ -16805,8 +16804,8 @@
       "Loxoscélico"
     ],
     "source_date": "2026-07-03",
-    "lat": -16.691849899999998,
-    "lng": -49.281811399999995,
+    "lat": -13.4101433,
+    "lng": -46.3018149,
     "geocode_tier": 1
   },
   {

--- a/data/location_overrides.json
+++ b/data/location_overrides.json
@@ -47,9 +47,10 @@
     "note": "Relatos comunitários (29/04 e 03/05/2026): policlínica desativada; serviço transferido para UPA 24h Dr. Luiz de Souza Dias (Rua Vereador Alfredo Mafuz, 525; tel. (31) 3764-9892). Confirme antes de se deslocar."
   },
   "2569701": {
-    "reason": "Hospital Municipal de São Domingos (São Domingos/GO) — relato comunitário (29/04/2026) de possível encerramento; mantido visível com nota até confirmação oficial.",
-    "verified_on": "2026-04-29",
-    "note": "Comunidade reportou (29/04/2026): possível encerramento. Confirme por telefone antes de se deslocar."
+    "reason": "Correção de coordenadas do Hospital Municipal de São Domingos (São Domingos/GO). O pin anterior apontava para um hospital particular em Goiânia; localização confirmada pelo endereço oficial do CNES/MS e geocodificação rooftop.",
+    "verified_on": "2026-08-12",
+    "lat": -13.4101433,
+    "lng": -46.3018149
   },
   "6483089": {
     "reason": "Hosp. Macrorregional de Urgência e Emergência de Presidente Dutra/SOCORRÃO (MA) — relato comunitário (29/04/2026) de telefone correto.",

--- a/hospitals.json
+++ b/hospitals.json
@@ -16785,7 +16785,6 @@
     "city": "São Domingos",
     "hospital_name": "Hospital Municipal de São Domingos",
     "address": "Rua Pedro Matias dos Santos, Qd 10, Lt 01-04 - Setor São Sebastião",
-    "note": "Comunidade reportou (29/04/2026): possível encerramento. Confirme por telefone antes de se deslocar.",
     "phones": [
       "(62) 3425-1598"
     ],
@@ -16805,8 +16804,8 @@
       "Loxoscélico"
     ],
     "source_date": "2026-07-03",
-    "lat": -16.691849899999998,
-    "lng": -49.281811399999995,
+    "lat": -13.4101433,
+    "lng": -46.3018149,
     "geocode_tier": 1
   },
   {


### PR DESCRIPTION
## Summary

- correct CNES 2569701 coordinates from the erroneous Goiânia match to the verified São Domingos rooftop result
- remove the unverified legacy community alert from the hospital card
- keep CNES 2241021 absent from the published dataset

## Validation

- `python3 scripts/validate_location_overrides.py`
- `python3 scripts/build_app_hospitals_json.py`
- `python3 scripts/validate_hospitals_json.py app/hospitals.json`
- `python3 scripts/rebuild_final_artifacts.py --check`
- `python3 -m pytest scripts/tests/ -q` (49 passed)
